### PR TITLE
Add note tooltips with octave numbers and enhance audio playback

### DIFF
--- a/src/app/guitar/GuitarNeck/FrettedNotes.tsx
+++ b/src/app/guitar/GuitarNeck/FrettedNotes.tsx
@@ -67,6 +67,7 @@ export const FrettedNotes: React.FC<FrettedNotesProps> = ({
               onClick={() => playNote(noteWithOctave)}
               className="cursor-pointer"
             >
+              <title>{noteWithOctave}</title>
               <circle
                 r={Math.min(stringSpacing / 3.5, stringSpacing / 3.5)}
                 fill={getNoteColor(note, scale, isDarkMode, highlightRoots)}

--- a/src/app/guitar/GuitarNeck/NotesDisplay.tsx
+++ b/src/app/guitar/GuitarNeck/NotesDisplay.tsx
@@ -65,6 +65,7 @@ export const NotesDisplay: React.FC<NotesDisplayProps> = ({
           }
           className="cursor-pointer"
         >
+          <title>{calculateNoteWithOctave(openNote, stringIndex, 0)}</title>
           <circle
             r={Math.min(stringSpacing / 3.5, stringSpacing / 3.5)}
             fill={getNoteColor(

--- a/src/lib/utils/audioUtils.ts
+++ b/src/lib/utils/audioUtils.ts
@@ -110,7 +110,11 @@ export const playNote = async (note: NoteWithOctave, duration: number = 0.5) => 
   if (!audioContext) return;
 
   try {
-    const frequency = calculateFrequency(note);
+    // Play the note one octave higher by adding 1 to the octave number
+    const baseNote = getBaseNote(note);
+    const originalOctave = getOctave(note);
+    const higherOctaveNote = `${baseNote}${originalOctave + 1}` as NoteWithOctave;
+    const frequency = calculateFrequency(higherOctaveNote);
 
     const oscillator = audioContext.createOscillator();
     const gainNode = audioContext.createGain();


### PR DESCRIPTION
- Add SVG tooltips to guitar notes showing note name with octave (e.g., "E2", "A3")
- Modify audio playback to play notes one octave higher for better audibility
- Tooltips appear on hover for both fretted notes and open string notes
- Audio enhancement makes guitar notes sound brighter and more prominent
- Maintains existing octave calculation system for accurate note identification

🤖 Generated with [Claude Code](https://claude.ai/code)