### PR TITLE
Convert custom tuning editor to popup modal

### DIFF
--- a/src/__tests__/CustomTuningEditor.test.tsx
+++ b/src/__tests__/CustomTuningEditor.test.tsx
@@ -12,6 +12,7 @@ describe("CustomTuningEditor", () => {
         onSaveTuning={onSaveMock}
         onCancel={onCancelMock}
         initialTuning={null}
+        customTunings={[]}
       />
     );
 
@@ -32,6 +33,7 @@ describe("CustomTuningEditor", () => {
         onSaveTuning={onSaveMock}
         onCancel={onCancelMock}
         initialTuning={null}
+        customTunings={[]}
       />
     );
 

--- a/src/app/guitar/Configuration/Configuration.tsx
+++ b/src/app/guitar/Configuration/Configuration.tsx
@@ -6,7 +6,6 @@ import { useDataContext } from "@/app/guitar/context";
 import { tuningGroups } from "@/app/guitar/tunings";
 import { TuningPresetWithMetadata, TUNING_PRESETS } from "../tuningConstants";
 import { MULTISCALE_PRESETS, PERPENDICULAR_FRET_OPTIONS } from "../multiscaleConstants";
-import { CustomTuningEditor } from "../CustomTuningEditor/CustomTuningEditor";
 
 export const Configuration: React.FC = () => {
   const {
@@ -40,13 +39,13 @@ export const Configuration: React.FC = () => {
     showCustomTuning,
     setShowCustomTuning,
     handleSaveCustomTuning,
+    openTuningEditor,
   } = useDataContext();
 
   const isDarkMode = useSelector(selectIsDarkMode);
 
   const handleEditTuning = (tuning: TuningPresetWithMetadata): void => {
-    setEditingTuning(tuning);
-    setShowCustomTuning(true);
+    openTuningEditor(tuning);
   };
   
   const handleDuplicateTuning = (tuning: TuningPresetWithMetadata) => {
@@ -91,8 +90,7 @@ export const Configuration: React.FC = () => {
                   value={scaleRoot.name}
                   onChange={(e) => {
                     if (e.target.value === "custom") {
-                      setShowCustomTuning(true);
-                      setEditingTuning(null);
+                      openTuningEditor(null);
                     } else {
                       const selectedTuning = [
                         ...TUNING_PRESETS,
@@ -442,22 +440,6 @@ export const Configuration: React.FC = () => {
             </>
           )}
         </div>
-        
-        {/* Custom Tuning Editor */}
-        {showCustomTuning && (
-          <div className="mt-4">
-            <CustomTuningEditor
-              initialTuning={editingTuning}
-              onSaveTuning={handleSaveCustomTuning}
-              onCancel={() => {
-                setShowCustomTuning(false);
-                setEditingTuning(null);
-              }}
-              customTunings={customTunings}
-            />
-          </div>
-        )}
-
       </div>
     </div>
   );

--- a/src/app/guitar/context.tsx
+++ b/src/app/guitar/context.tsx
@@ -88,6 +88,7 @@ export interface DataContextType {
   showCustomTuning: boolean;
   setShowCustomTuning: (show: boolean) => void;
   handleSaveCustomTuning: (tuning: TuningPreset) => void;
+  openTuningEditor: (tuning?: TuningPresetWithMetadata | null) => void;
 }
 
 // Create context with proper default values to avoid runtime errors
@@ -126,11 +127,18 @@ const defaultContextValue: DataContextType = {
   showCustomTuning: false,
   setShowCustomTuning: () => {},
   handleSaveCustomTuning: () => {},
+  openTuningEditor: () => {},
 };
 
 export const DataContext = createContext<DataContextType>(defaultContextValue);
 
-export const DataProvider = ({ children }: { children: ReactNode }) => {
+interface DataProviderProps {
+  children: ReactNode;
+  customTunings?: TuningPresetWithMetadata[];
+  openTuningEditor?: (tuning?: TuningPresetWithMetadata | null) => void;
+}
+
+export const DataProvider = ({ children, customTunings: propCustomTunings, openTuningEditor: propOpenTuningEditor }: DataProviderProps) => {
   // Display settings with localStorage persistence
   const [flipX, setFlipX] = useLocalStorageBoolean("flip-x", false);
   const [flipY, setFlipY] = useLocalStorageBoolean("flip-y", false);
@@ -152,6 +160,10 @@ export const DataProvider = ({ children }: { children: ReactNode }) => {
   // Tuning management state (scaleRoot must be declared before per-string state that uses it)
   const [scaleRoot, setScaleRoot] = useLocalStorage<TuningPreset>("current-scaleRoot", getTuning());
   const [customTunings, setCustomTunings] = useLocalStorage<TuningPresetWithMetadata[]>("custom-tunings", getCustomTunings());
+
+  // Use prop custom tunings if provided (for popup mode)
+  const effectiveCustomTunings = propCustomTunings || customTunings;
+  const setEffectiveCustomTunings = propCustomTunings ? () => {} : setCustomTunings;
 
   // Per-string enabled state (checkbox on the left of each string). Persisted.
   const [stringEnabledStored, setStringEnabledStored] = useLocalStorage<boolean[]>("guitar-string-enabled", []);
@@ -209,6 +221,13 @@ export const DataProvider = ({ children }: { children: ReactNode }) => {
   // Rest of tuning management state
   const [editingTuning, setEditingTuning] = useState<TuningPresetWithMetadata | null>(null);
   const [showCustomTuning, setShowCustomTuning] = useState(false);
+
+  // Use prop openTuningEditor if provided (for popup mode)
+  const openTuningEditor = propOpenTuningEditor || ((tuning?: TuningPresetWithMetadata | null) => {
+    // Default behavior when not in popup mode
+    setEditingTuning(tuning || null);
+    setShowCustomTuning(true);
+  });
   
   // Update scale length when tuning changes if multiscale is enabled
   useEffect(() => {
@@ -225,17 +244,17 @@ export const DataProvider = ({ children }: { children: ReactNode }) => {
     const customTuning: TuningPresetWithMetadata = {
       ...newTuning,
       description: `Custom ${newTuning.strings.length}-string tuning`,
-      category: "Special",
+      category: "Custom",
     };
 
     if (editingTuning) {
-      setCustomTunings((prevTunings) =>
+      setEffectiveCustomTunings((prevTunings) =>
         prevTunings.map((t) =>
           t.name === editingTuning.name ? customTuning : t
         )
       );
     } else {
-      setCustomTunings((prevTunings) => [...prevTunings, customTuning]);
+      setEffectiveCustomTunings((prevTunings) => [...prevTunings, customTuning]);
     }
 
     setScaleRoot(customTuning);
@@ -273,13 +292,14 @@ export const DataProvider = ({ children }: { children: ReactNode }) => {
         // Tuning management
         scaleRoot,
         setScaleRoot,
-        customTunings,
-        setCustomTunings,
+        customTunings: effectiveCustomTunings,
+        setCustomTunings: setEffectiveCustomTunings,
         editingTuning,
         setEditingTuning,
         showCustomTuning,
         setShowCustomTuning,
         handleSaveCustomTuning,
+        openTuningEditor,
       }}
     >
       {children}

--- a/src/app/guitar/page.tsx
+++ b/src/app/guitar/page.tsx
@@ -1,17 +1,104 @@
 "use client";
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { GuitarNeck } from "./GuitarNeck/GuitarNeck";
 import { Configuration } from "./Configuration/Configuration";
 import { DataProvider } from "./context";
+import { CustomTuningEditor } from "./CustomTuningEditor/CustomTuningEditor";
+import { TuningPresetWithMetadata } from "./tuningConstants";
+import { TuningPreset } from "./types/tuningPreset";
+import { useSelector } from "react-redux";
+import { selectIsDarkMode } from "@/features/globalConfig/globalConfigSlice";
+import { useLocalStorage } from "./hooks/useLocalStorage";
 
 export default function Guitar() {
+  const isDarkMode = useSelector(selectIsDarkMode);
+  const [showTuningEditor, setShowTuningEditor] = useState(false);
+  const [editingTuning, setEditingTuning] = useState<TuningPresetWithMetadata | null>(null);
+
+  // Load custom tunings from localStorage
+  const [customTunings, setCustomTuningsStorage] = useLocalStorage<TuningPresetWithMetadata[]>(
+    "custom-tunings",
+    []
+  );
+
+  // Migrate existing custom tunings from "Special" to "Custom" category
+  useEffect(() => {
+    setCustomTuningsStorage((prevTunings) =>
+      prevTunings.map((tuning) =>
+        tuning.category === "Special"
+          ? { ...tuning, category: "Custom" }
+          : tuning
+      )
+    );
+  }, [setCustomTuningsStorage]);
+
+  const handleSaveCustomTuning = (tuning: TuningPreset) => {
+    const customTuning: TuningPresetWithMetadata = {
+      ...tuning,
+      description: `Custom ${tuning.strings.length}-string tuning`,
+      category: "Custom",
+    };
+
+    if (editingTuning) {
+      // Update existing tuning
+      setCustomTuningsStorage((prevTunings) =>
+        prevTunings.map((t) =>
+          t.name === editingTuning.name ? customTuning : t
+        )
+      );
+    } else {
+      // Add new tuning
+      setCustomTuningsStorage((prevTunings) => [...prevTunings, customTuning]);
+    }
+
+    setShowTuningEditor(false);
+    setEditingTuning(null);
+  };
+
+  const openTuningEditor = (tuning?: TuningPresetWithMetadata | null) => {
+    setEditingTuning(tuning || null);
+    setShowTuningEditor(true);
+  };
 
   return (
     <div className="w-full space-y-6">
-      <DataProvider>
+      <DataProvider
+        customTunings={customTunings}
+        openTuningEditor={openTuningEditor}
+      >
         <GuitarNeck />
         <Configuration />
       </DataProvider>
+
+      {showTuningEditor && (
+        <div
+          className={`fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm ${
+            isDarkMode ? "bg-black/50" : "bg-white/50"
+          }`}
+          onClick={() => {
+            setShowTuningEditor(false);
+            setEditingTuning(null);
+          }}
+          role="presentation"
+        >
+          <div
+            className={`rounded-lg shadow-xl max-w-4xl w-full p-6 max-h-[90vh] overflow-y-auto ${
+              isDarkMode ? "bg-gray-800" : "bg-white"
+            }`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <CustomTuningEditor
+              initialTuning={editingTuning}
+              onSaveTuning={handleSaveCustomTuning}
+              onCancel={() => {
+                setShowTuningEditor(false);
+                setEditingTuning(null);
+              }}
+              customTunings={customTunings}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Changes

- Converted the custom tuning editor from an embedded component to a popup modal (like the scale editor)
- Changed custom tuning category from 'Special' to 'Custom' for better organization
- Added migration logic to update existing custom tunings
- Updated tests and ensured TypeScript compilation

## Testing
- All tests passing (79 tests)
- TypeScript compilation successful
- Verified popup functionality works correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors custom-tuning state ownership and persistence, including a localStorage migration that could affect existing user data if incorrect.
> 
> **Overview**
> Moves the `CustomTuningEditor` from an inline section in `Configuration` to a page-level modal overlay opened via a new `openTuningEditor` context action.
> 
> Refactors `DataProvider` to optionally accept `customTunings` and an `openTuningEditor` callback (for popup mode) and updates custom tuning saves to use an effective setter, while reclassifying new custom tunings from **`Special`** to **`Custom`**.
> 
> Adds a one-time migration in `guitar/page.tsx` to update any persisted custom tunings with category `Special` to `Custom`, and updates the `CustomTuningEditor` test to pass the required `customTunings` prop.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11013540fdfec72de995b88687ec8a9d835bd482. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->