### PR TITLE
Fix custom tuning deletion bug

### DIFF
--- a/src/__tests__/CustomTuningDeletion.test.tsx
+++ b/src/__tests__/CustomTuningDeletion.test.tsx
@@ -1,0 +1,159 @@
+import { screen, fireEvent, waitFor } from "@testing-library/react";
+import { Configuration } from "../app/guitar/Configuration/Configuration";
+import { renderWithProviders } from "./test-utils";
+import { DataProvider } from "../app/guitar/context";
+
+// Mock window.confirm
+const mockConfirm = jest.fn();
+window.confirm = mockConfirm;
+
+describe("Custom Tuning Deletion", () => {
+  beforeEach(() => {
+    mockConfirm.mockClear();
+    // Clear localStorage
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("should delete a custom tuning when confirmed", async () => {
+    // Setup initial custom tunings
+    const initialCustomTunings = [
+      {
+        name: "Test Tuning",
+        strings: ["E", "A", "D", "G", "B", "E"] as const,
+        description: "Test tuning",
+        category: "Custom" as const,
+      },
+    ];
+
+    // Set the custom tuning in localStorage
+    localStorage.setItem("custom-tunings", JSON.stringify(initialCustomTunings));
+    localStorage.setItem("current-scaleRoot", JSON.stringify(initialCustomTunings[0]));
+
+    const { container } = renderWithProviders(
+      <DataProvider>
+        <Configuration />
+      </DataProvider>
+    );
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Test Tuning (Custom)")).toBeInTheDocument();
+    });
+
+    // Mock confirm to return true (user clicks "OK")
+    mockConfirm.mockReturnValue(true);
+
+    // Click the delete button
+    const deleteButton = screen.getByText("Delete");
+    fireEvent.click(deleteButton);
+
+    // Verify confirm was called
+    expect(mockConfirm).toHaveBeenCalledWith("Are you sure you want to delete this custom tuning?");
+
+    // Wait for the tuning to be removed from the dropdown
+    await waitFor(() => {
+      const select = screen.getByDisplayValue("Standard (6)") as HTMLSelectElement;
+      expect(select.value).toBe("Standard (6)");
+    });
+
+    // Wait for localStorage to be updated (debounced save)
+    await waitFor(() => {
+      const updatedTunings = JSON.parse(localStorage.getItem("custom-tunings") || "[]");
+      expect(updatedTunings).toHaveLength(0);
+    }, { timeout: 1000 }); // Increase timeout for debounced save
+  });
+
+  it("should not delete a custom tuning when cancelled", async () => {
+    // Setup initial custom tunings
+    const initialCustomTunings = [
+      {
+        name: "Test Tuning",
+        strings: ["E", "A", "D", "G", "B", "E"] as const,
+        description: "Test tuning",
+        category: "Custom" as const,
+      },
+    ];
+
+    // Set the custom tuning in localStorage
+    localStorage.setItem("custom-tunings", JSON.stringify(initialCustomTunings));
+    localStorage.setItem("current-scaleRoot", JSON.stringify(initialCustomTunings[0]));
+
+    renderWithProviders(
+      <DataProvider>
+        <Configuration />
+      </DataProvider>
+    );
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Test Tuning (Custom)")).toBeInTheDocument();
+    });
+
+    // Mock confirm to return false (user clicks "Cancel")
+    mockConfirm.mockReturnValue(false);
+
+    // Click the delete button
+    const deleteButton = screen.getByText("Delete");
+    fireEvent.click(deleteButton);
+
+    // Verify confirm was called
+    expect(mockConfirm).toHaveBeenCalledWith("Are you sure you want to delete this custom tuning?");
+
+    // Verify the tuning was NOT removed from the dropdown
+    expect(screen.getByDisplayValue("Test Tuning (Custom)")).toBeInTheDocument();
+
+    // Verify the tuning was NOT removed from localStorage
+    const updatedTunings = JSON.parse(localStorage.getItem("custom-tunings") || "[]");
+    expect(updatedTunings).toHaveLength(1);
+    expect(updatedTunings[0].name).toBe("Test Tuning");
+  });
+
+  it("should reset to standard tuning when deleting the currently selected custom tuning", async () => {
+    // Setup initial custom tunings
+    const initialCustomTunings = [
+      {
+        name: "Test Tuning",
+        strings: ["D", "A", "D", "G", "A", "D"] as const,
+        description: "Test tuning",
+        category: "Custom" as const,
+      },
+    ];
+
+    // Set the custom tuning as current
+    localStorage.setItem("custom-tunings", JSON.stringify(initialCustomTunings));
+    localStorage.setItem("current-scaleRoot", JSON.stringify(initialCustomTunings[0]));
+
+    renderWithProviders(
+      <DataProvider>
+        <Configuration />
+      </DataProvider>
+    );
+
+    // Wait for the component to load
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Test Tuning (Custom)")).toBeInTheDocument();
+    });
+
+    // Mock confirm to return true
+    mockConfirm.mockReturnValue(true);
+
+    // Click the delete button
+    const deleteButton = screen.getByText("Delete");
+    fireEvent.click(deleteButton);
+
+    // Verify we switched to Standard tuning
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Standard (6)")).toBeInTheDocument();
+    });
+
+    // Wait for localStorage to be updated (debounced save)
+    await waitFor(() => {
+      const currentTuning = JSON.parse(localStorage.getItem("current-scaleRoot") || "{}");
+      expect(currentTuning.name).toBe("Standard (6)");
+    }, { timeout: 1000 }); // Increase timeout for debounced save
+  });
+});

--- a/src/app/guitar/Configuration/Configuration.tsx
+++ b/src/app/guitar/Configuration/Configuration.tsx
@@ -7,7 +7,11 @@ import { tuningGroups } from "@/app/guitar/tunings";
 import { TuningPresetWithMetadata, TUNING_PRESETS } from "../tuningConstants";
 import { MULTISCALE_PRESETS, PERPENDICULAR_FRET_OPTIONS } from "../multiscaleConstants";
 
-export const Configuration: React.FC = () => {
+interface ConfigurationProps {
+  onDeleteCustomTuning?: (tuningName: string) => void;
+}
+
+export const Configuration: React.FC<ConfigurationProps> = ({ onDeleteCustomTuning }) => {
   const {
     // Display settings
     flipX,
@@ -34,6 +38,8 @@ export const Configuration: React.FC = () => {
     customTunings,
     setEditingTuning,
     setCustomTunings,
+    saveCustomTuningsImmediately,
+    saveScaleRootImmediately,
     setScaleRoot,
     editingTuning,
     showCustomTuning,
@@ -57,15 +63,44 @@ export const Configuration: React.FC = () => {
   };
   
   const handleDeleteTuning = (tuningName: string) => {
+    console.log("[DELETE] Attempting to delete tuning:", tuningName);
+    console.log("[DELETE] Current custom tunings:", customTunings);
+
     if (confirm("Are you sure you want to delete this custom tuning?")) {
-      setCustomTunings((prevTunings) =>
-        prevTunings.filter((t) => t.name !== tuningName)
-      );
+      console.log("[DELETE] User confirmed deletion");
+
+      // Filter out the deleted tuning
+      const filteredTunings = customTunings.filter((t) => t.name !== tuningName);
+      console.log("[DELETE] Filtered tunings:", filteredTunings);
+
+      // If parent provided a callback, use it (for prop-based management)
+      if (onDeleteCustomTuning) {
+        console.log("[DELETE] Using parent callback");
+        onDeleteCustomTuning(tuningName);
+      } else {
+        // Otherwise, use the context-based approach
+        console.log("[DELETE] Using context-based approach");
+
+        // Update state
+        setCustomTunings(filteredTunings);
+        console.log("[DELETE] State updated");
+
+        // Immediately save to localStorage (don't wait for debounce)
+        saveCustomTuningsImmediately(filteredTunings);
+        console.log("[DELETE] Saved to localStorage immediately");
+      }
 
       // If the deleted tuning was selected, switch to standard tuning
       if (scaleRoot.name === tuningName) {
-        setScaleRoot(TUNING_PRESETS[0]);
+        console.log("[DELETE] Deleted tuning was selected, switching to standard");
+        const standardTuning = TUNING_PRESETS[0];
+        setScaleRoot(standardTuning);
+        // Immediately save the new current tuning
+        saveScaleRootImmediately(standardTuning);
+        console.log("[DELETE] Switched to standard tuning:", standardTuning.name);
       }
+    } else {
+      console.log("[DELETE] User cancelled deletion");
     }
   };
 

--- a/src/app/guitar/context.tsx
+++ b/src/app/guitar/context.tsx
@@ -83,6 +83,8 @@ export interface DataContextType {
   setScaleRoot: (tuning: TuningPreset) => void;
   customTunings: TuningPresetWithMetadata[];
   setCustomTunings: (tunings: TuningPresetWithMetadata[] | ((prev: TuningPresetWithMetadata[]) => TuningPresetWithMetadata[])) => void;
+  saveCustomTuningsImmediately: (tunings: TuningPresetWithMetadata[]) => void;
+  saveScaleRootImmediately: (tuning: TuningPreset) => void;
   editingTuning: TuningPresetWithMetadata | null;
   setEditingTuning: (tuning: TuningPresetWithMetadata | null) => void;
   showCustomTuning: boolean;
@@ -122,6 +124,8 @@ const defaultContextValue: DataContextType = {
   setScaleRoot: () => {},
   customTunings: [],
   setCustomTunings: () => {},
+  saveCustomTuningsImmediately: () => {},
+  saveScaleRootImmediately: () => {},
   editingTuning: null,
   setEditingTuning: () => {},
   showCustomTuning: false,
@@ -158,8 +162,8 @@ export const DataProvider = ({ children, customTunings: propCustomTunings, openT
   const [stringSpacing, setStringSpacing] = useLocalStorage<'normal' | 'enlarged'>("string-spacing", "normal");
 
   // Tuning management state (scaleRoot must be declared before per-string state that uses it)
-  const [scaleRoot, setScaleRoot] = useLocalStorage<TuningPreset>("current-scaleRoot", getTuning());
-  const [customTunings, setCustomTunings] = useLocalStorage<TuningPresetWithMetadata[]>("custom-tunings", getCustomTunings());
+  const [scaleRoot, setScaleRoot, saveScaleRootImmediately] = useLocalStorage<TuningPreset>("current-scaleRoot", getTuning());
+  const [customTunings, setCustomTunings, saveCustomTuningsImmediately] = useLocalStorage<TuningPresetWithMetadata[]>("custom-tunings", getCustomTunings());
 
   // Use prop custom tunings if provided (for popup mode)
   const effectiveCustomTunings = propCustomTunings || customTunings;
@@ -294,6 +298,8 @@ export const DataProvider = ({ children, customTunings: propCustomTunings, openT
         setScaleRoot,
         customTunings: effectiveCustomTunings,
         setCustomTunings: setEffectiveCustomTunings,
+        saveCustomTuningsImmediately,
+        saveScaleRootImmediately,
         editingTuning,
         setEditingTuning,
         showCustomTuning,

--- a/src/app/guitar/hooks/useLocalStorage.ts
+++ b/src/app/guitar/hooks/useLocalStorage.ts
@@ -4,7 +4,7 @@ export function useLocalStorage<T>(
   key: string,
   defaultValue: T,
   debounceMs: number = 300
-): [T, (value: T | ((prev: T) => T)) => void] {
+): [T, (value: T | ((prev: T) => T)) => void, (value: T) => void] {
   // Initialize state with default value to prevent hydration mismatch
   const [storedValue, setStoredValue] = useState<T>(defaultValue);
   const [isHydrated, setIsHydrated] = useState(false);
@@ -65,6 +65,22 @@ export function useLocalStorage<T>(
     });
   }, [debouncedSave]);
 
+  // Immediate save without debounce
+  const saveImmediately = useCallback((value: T) => {
+    if (typeof window === 'undefined' || !isHydrated) return;
+
+    // Clear any pending debounced save
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn(`Failed to immediately save ${key} to localStorage:`, error);
+    }
+  }, [key, isHydrated]);
+
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
@@ -74,7 +90,7 @@ export function useLocalStorage<T>(
     };
   }, []);
 
-  return [storedValue, setValue];
+  return [storedValue, setValue, saveImmediately];
 }
 
 // Specialized hook for boolean values with string storage

--- a/src/app/guitar/page.tsx
+++ b/src/app/guitar/page.tsx
@@ -32,6 +32,15 @@ export default function Guitar() {
     );
   }, [setCustomTuningsStorage]);
 
+  const handleDeleteCustomTuning = (tuningName: string) => {
+    console.log("[Guitar Page] Deleting custom tuning:", tuningName);
+    setCustomTuningsStorage((prevTunings) => {
+      const filtered = prevTunings.filter((t) => t.name !== tuningName);
+      console.log("[Guitar Page] Filtered tunings:", filtered);
+      return filtered;
+    });
+  };
+
   const handleSaveCustomTuning = (tuning: TuningPreset) => {
     const customTuning: TuningPresetWithMetadata = {
       ...tuning,
@@ -67,7 +76,7 @@ export default function Guitar() {
         openTuningEditor={openTuningEditor}
       >
         <GuitarNeck />
-        <Configuration />
+        <Configuration onDeleteCustomTuning={handleDeleteCustomTuning} />
       </DataProvider>
 
       {showTuningEditor && (


### PR DESCRIPTION
## Problem
Custom tunings were not being deleted after confirming the deletion. The tuning would remain in the list and still be accessible after page refresh.

## Root Cause
The guitar page was managing its own localStorage state for custom tunings and passing it as a prop to the DataProvider. When the Configuration component tried to delete a tuning, the DataProvider's `setCustomTunings` function was disabled (became a no-op) because it detected prop-based state management.

## Solution
- Added a callback prop `onDeleteCustomTuning` to the Configuration component
- Updated the guitar page to provide a delete handler that properly updates the page's localStorage state
- Added immediate save function to useLocalStorage hook for critical operations
- Added comprehensive tests for the deletion functionality

## Changes
- `Configuration.tsx`: Added callback prop support for deletion
- `page.tsx`: Added delete handler and passed it to Configuration
- `context.tsx`: Added immediate save functions to context
- `useLocalStorage.ts`: Added `saveImmediately` function for non-debounced saves
- Added `CustomTuningDeletion.test.tsx` with test coverage

## Testing
- All existing tests pass
- New tests verify deletion works correctly
- Build succeeds without errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `useLocalStorage` hook API and tuning persistence behavior, which could impact any other callers expecting the old tuple shape or debounce-only writes.
> 
> **Overview**
> Fixes a bug where deleting a custom tuning didn’t persist when tunings are managed by the page (prop-driven `DataProvider`). `Configuration` now supports an `onDeleteCustomTuning` callback and, when deleting via context, forces immediate localStorage writes for both `custom-tunings` and `current-scaleRoot` (resetting to standard if the active tuning is deleted).
> 
> Extends `useLocalStorage` to return a third function for non-debounced saves, wires these immediate-save helpers through `DataProvider`, and adds a new test suite (`CustomTuningDeletion.test.tsx`) covering confirm/cancel flows and resetting the selected tuning after deletion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04a0e48721a90eda64238d3951cf94d1d673be36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->