### PR TITLE
Feat/rework flute view

### DIFF
--- a/src/app/flute/FluteDiagram.tsx
+++ b/src/app/flute/FluteDiagram.tsx
@@ -20,6 +20,41 @@ const sharpToFlat = (note: Note): Note => {
   return SHARP_TO_FLAT[note] || note;
 };
 
+/* ------------------------------------------------------------------ */
+/*  Realistic key layout for a Boehm-system concert flute             */
+/*  Positions are percentages along the tube (0 = head, 100 = foot)   */
+/* ------------------------------------------------------------------ */
+
+interface KeyLayout {
+  x: number; // 0–100 along the tube
+  y: number; // vertical offset from tube center (- = above, + = below)
+  type: "hole" | "lever-left" | "lever-right" | "foot";
+  rx?: number; // ellipse radius x (for holes)
+  ry?: number; // ellipse radius y
+  width?: number; // for levers
+  height?: number;
+}
+
+const KEY_LAYOUTS: Record<string, KeyLayout> = {
+  thumb:   { x: 6,  y: -10, type: "hole", rx: 5.5, ry: 4 },
+  l1:      { x: 16, y: 0,   type: "hole", rx: 5.5, ry: 4 },
+  l2:      { x: 26, y: 0,   type: "hole", rx: 5.5, ry: 4 },
+  l3:      { x: 36, y: 0,   type: "hole", rx: 5.5, ry: 4 },
+  r1:      { x: 48, y: 0,   type: "hole", rx: 5.5, ry: 4 },
+  r2:      { x: 58, y: 0,   type: "hole", rx: 5.5, ry: 4 },
+  r3:      { x: 68, y: 0,   type: "hole", rx: 5.5, ry: 4 },
+  eb:      { x: 72, y: 10,  type: "lever-right", width: 7, height: 3.5 },
+  gsharp:  { x: 78, y: -10, type: "lever-left",  width: 7, height: 3.5 },
+  c:       { x: 84, y: 0,   type: "hole", rx: 5, ry: 3.5 },
+  csharp:  { x: 88, y: 10,  type: "lever-right", width: 6, height: 3 },
+  b:       { x: 92, y: -10, type: "lever-left",  width: 6, height: 3 },
+  lowc:    { x: 97, y: 8,   type: "foot", width: 5, height: 4 },
+  lowcsharp:{ x: 97, y: -8,  type: "foot", width: 5, height: 4 },
+  lowd:    { x: 94, y: 0,   type: "hole", rx: 4.5, ry: 3.5 },
+};
+
+/* ------------------------------------------------------------------ */
+
 export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   note,
   scale,
@@ -31,11 +66,8 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   const [isFocused, setIsFocused] = React.useState(false);
   const fingering = getFluteFingering(note);
 
-  // Extract note name and octave
   const match = note.match(/^([A-G][#b]?)(\d+)$/);
   const noteName = match ? (match[1] as Note) : ("C" as Note);
-  const octave = match ? parseInt(match[2], 10) : 4;
-  const startOctave = 4;
 
   const handleClick = () => onPlay(note);
   const handleKeyDown = (e: React.KeyboardEvent<SVGGElement>) => {
@@ -46,8 +78,11 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   };
 
   const closedFill = isDarkMode ? "#d1d5db" : "#1f2937";
-  const openStroke = isDarkMode ? "#d1d5db" : "#1f2937";
-  const bodyFill = isDarkMode ? "#4b5563" : "#d1d5db";
+  const openStroke = isDarkMode ? "#9ca3af" : "#4b5563";
+  const tubeFill = isDarkMode ? "#374151" : "#e5e7eb";
+  const tubeStroke = isDarkMode ? "#6b7280" : "#9ca3af";
+  const leverFill = isDarkMode ? "#6b7280" : "#d1d5db";
+  const leverStroke = isDarkMode ? "#9ca3af" : "#6b7280";
 
   const labelText = (() => {
     if (displayMode === "degree") {
@@ -61,6 +96,16 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
 
   const noteColor = getScaleNoteColor(noteName, scale, isDarkMode, highlightRoots);
 
+  /* helpers ---------------------------------------------------------- */
+  const keyState = (id: string) =>
+    fingering?.keys.find((k) => k.keyId === id);
+
+  const isClosed = (id: string) => keyState(id)?.closed ?? false;
+
+  const tubeLength = 260;
+  const tubeY = 50;
+  const tubeH = 24;
+
   return (
     <g
       onClick={handleClick}
@@ -73,84 +118,172 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
       className="cursor-pointer focus:outline-none"
       style={{ outline: "none" }}
     >
-      {/* Focus ring */}
+      {/* Focus outline */}
       {isFocused && (
         <rect
-          x={-36}
-          y={0}
-          width={72}
-          height={350}
-          rx={6}
+          x={-8}
+          y={-14}
+          width={tubeLength + 56}
+          height={tubeH + 52}
+          rx={8}
           fill="none"
           stroke="#3b82f6"
-          strokeWidth={3}
+          strokeWidth={2.5}
           className="transition-colors duration-200"
         />
       )}
 
-      {/* Note label above flute body */}
+      {/* Note label */}
       <text
-        x={0}
-        y={20}
+        x={tubeLength / 2 + 20}
+        y={-2}
         textAnchor="middle"
         dominantBaseline="middle"
         fill={noteColor}
-        fontSize="16"
+        fontSize="15"
         fontWeight="bold"
         className="select-none"
       >
         {labelText}
       </text>
 
-      {/* Octave indicator when different from starting octave */}
-      {octave !== startOctave && (
-        <text
-          x={0}
-          y={36}
-          textAnchor="middle"
-          dominantBaseline="middle"
-          fill={isDarkMode ? "#9ca3af" : "#6b7280"}
-          fontSize="10"
-          className="select-none"
-        >
-          {octave}
-        </text>
-      )}
+      {/* ====== FLUTE BODY ====== */}
 
-      {/* Flute body */}
+      {/* Main tube */}
       <rect
-        x={-30}
-        y={44}
-        width={60}
-        height={300}
-        rx={4}
-        fill={bodyFill}
+        x={0}
+        y={tubeY}
+        width={tubeLength}
+        height={tubeH}
+        rx={12}
+        fill={tubeFill}
+        stroke={tubeStroke}
+        strokeWidth={1}
         className="transition-colors duration-200"
       />
 
-      {/* Key holes */}
-      {fingering?.keys.map((key, i) => (
-        <g key={key.keyId} transform={`translate(0, ${60 + i * 18})`}>
-          <circle
-            r={8}
-            fill={key.closed ? closedFill : "none"}
-            stroke={openStroke}
-            strokeWidth={2}
-            className="transition-colors duration-200"
-          />
-          {/* Key label */}
-          <text
-            x={20}
-            y={0}
-            dominantBaseline="middle"
-            fill={isDarkMode ? "#d1d5db" : "#374151"}
-            fontSize="9"
-            className="select-none"
-          >
-            {key.label}
-          </text>
-        </g>
-      ))}
+      {/* Embouchure hole (lip plate) */}
+      <ellipse
+        cx={14}
+        cy={tubeY + tubeH / 2}
+        rx={10}
+        ry={7}
+        fill={isDarkMode ? "#1f2937" : "#f3f4f6"}
+        stroke={tubeStroke}
+        strokeWidth={1}
+      />
+      <ellipse
+        cx={14}
+        cy={tubeY + tubeH / 2}
+        rx={6}
+        ry={4}
+        fill={isDarkMode ? "#111827" : "#d1d5db"}
+      />
+
+      {/* Tenon joints (subtle rings) */}
+      <rect x={78} y={tubeY - 1} width={3} height={tubeH + 2} rx={1} fill={tubeStroke} opacity={0.5} />
+      <rect x={158} y={tubeY - 1} width={3} height={tubeH + 2} rx={1} fill={tubeStroke} opacity={0.5} />
+
+      {/* Foot joint end cap */}
+      <rect
+        x={tubeLength - 4}
+        y={tubeY + 2}
+        width={4}
+        height={tubeH - 4}
+        rx={2}
+        fill={tubeStroke}
+        opacity={0.6}
+      />
+
+      {/* ====== KEYS ====== */}
+
+      {fingering?.keys.map((key) => {
+        const layout = KEY_LAYOUTS[key.keyId];
+        if (!layout) return null;
+
+        const kx = (layout.x / 100) * tubeLength;
+        const ky = tubeY + tubeH / 2 + layout.y;
+
+        if (layout.type === "hole") {
+          return (
+            <g key={key.keyId}>
+              {/* Pad cup (key surround) */}
+              <ellipse
+                cx={kx}
+                cy={ky}
+                rx={(layout.rx ?? 5) + 2}
+                ry={(layout.ry ?? 4) + 1.5}
+                fill={isDarkMode ? "#4b5563" : "#9ca3af"}
+                opacity={0.4}
+              />
+              {/* Hole */}
+              <ellipse
+                cx={kx}
+                cy={ky}
+                rx={layout.rx ?? 5}
+                ry={layout.ry ?? 4}
+                fill={key.closed ? closedFill : "none"}
+                stroke={openStroke}
+                strokeWidth={1.8}
+                className="transition-colors duration-200"
+              />
+            </g>
+          );
+        }
+
+        /* lever or foot key */
+        const lw = layout.width ?? 6;
+        const lh = layout.height ?? 3;
+        return (
+          <g key={key.keyId}>
+            {/* Lever arm */}
+            <line
+              x1={kx}
+              y1={tubeY + tubeH / 2}
+              x2={kx}
+              y2={ky}
+              stroke={leverStroke}
+              strokeWidth={1.2}
+              opacity={0.6}
+            />
+            {/* Lever pad */}
+            <rect
+              x={kx - lw / 2}
+              y={ky - lh / 2}
+              width={lw}
+              height={lh}
+              rx={1.5}
+              fill={key.closed ? closedFill : leverFill}
+              stroke={openStroke}
+              strokeWidth={1.5}
+              className="transition-colors duration-200"
+            />
+          </g>
+        );
+      })}
+
+      {/* ====== KEY LABELS (mini legend below) ====== */}
+      <g transform={`translate(0, ${tubeY + tubeH + 14})`}>
+        {fingering?.keys.map((key, i) => {
+          const layout = KEY_LAYOUTS[key.keyId];
+          if (!layout) return null;
+          const kx = (layout.x / 100) * tubeLength;
+          return (
+            <text
+              key={`label-${key.keyId}`}
+              x={kx}
+              y={0}
+              textAnchor="middle"
+              dominantBaseline="middle"
+              fill={isDarkMode ? "#9ca3af" : "#4b5563"}
+              fontSize="7"
+              className="select-none"
+            >
+              {key.label}
+            </text>
+          );
+        })}
+      </g>
     </g>
   );
 };

--- a/src/app/flute/FluteDiagram.tsx
+++ b/src/app/flute/FluteDiagram.tsx
@@ -3,287 +3,213 @@
 import React from "react";
 import { Note, NoteWithOctave } from "@/lib/utils/note";
 import { Scale } from "@/lib/utils/scaleType";
-import { getScaleDegree, SHARP_TO_FLAT } from "@/lib/utils/scaleUtils";
-import { getFluteFingering } from "@/lib/utils/fluteUtils";
-import { getScaleNoteColor } from "@/app/guitar/GuitarNeck/getScaleNoteColor";
+import { getScaleDegree, SHARP_TO_FLAT, getScaleNotes } from "@/lib/utils/scaleUtils";
 
-export interface FluteDiagramProps {
+interface FluteDiagramProps {
   note: NoteWithOctave;
   scale: Scale;
-  displayMode: "note" | "flat" | "degree";
+  displayMode: "note" | "degree" | "flat";
   isDarkMode: boolean;
   highlightRoots: boolean;
-  onPlay: (note: NoteWithOctave) => void;
+  onPlay: (noteWithOctave: NoteWithOctave) => void;
 }
 
-const sharpToFlat = (note: Note): Note => {
-  return SHARP_TO_FLAT[note] || note;
+type KeyDef = {
+  name: string;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  r: number;
+  labelDy: number;
 };
 
-/* ------------------------------------------------------------------ */
-/*  Realistic key layout for a Boehm-system concert flute             */
-/*  Positions are percentages along the tube (0 = head, 100 = foot)   */
-/* ------------------------------------------------------------------ */
+const DIAGRAM_W = 122;
+const DIAGRAM_H = 320;
+const TUBE_CX = 61;
+const TUBE_W = 24;
+const TUBE_X = TUBE_CX - TUBE_W / 2;
 
-interface KeyLayout {
-  x: number; // 0–100 along the tube
-  y: number; // vertical offset from tube center (- = above, + = below)
-  type: "hole" | "lever-left" | "lever-right" | "foot";
-  rx?: number; // ellipse radius x (for holes)
-  ry?: number; // ellipse radius y
-  width?: number; // for levers
-  height?: number;
-}
+const KEYS: KeyDef[] = [
+  { name: "thumb_B", x: 38, y: 10, w: 12, h: 9, r: 5, labelDy: -8 },
+  { name: "thumb_C", x: 38, y: 24, w: 12, h: 9, r: 5, labelDy: -8 },
+  { name: "thumb_D", x: 38, y: 38, w: 12, h: 9, r: 5, labelDy: -8 },
+  { name: "G_key",  x: 38, y: 54, w: 12, h: 9, r: 5, labelDy: -8 },
+  { name: "Eb",     x: 84, y: 88, w: 10, h: 8, r: 4, labelDy: -8 },
+  { name: "F",      x: 84, y: 100, w: 10, h: 8, r: 4, labelDy: -8 },
+  { name: "F#",     x: 84, y: 112, w: 10, h: 8, r: 4, labelDy: -8 },
+  { name: "G",      x: 84, y: 124, w: 10, h: 8, r: 4, labelDy: -8 },
+  { name: "G#",     x: 36, y: 212, w: 10, h: 8, r: 4, labelDy: 12 },
+  { name: "C_foot", x: 61, y: 224, w: 10, h: 8, r: 4, labelDy: 12 },
+  { name: "C#",     x: 86, y: 212, w: 10, h: 8, r: 4, labelDy: 12 },
+];
 
-const KEY_LAYOUTS: Record<string, KeyLayout> = {
-  thumb:   { x: 6,  y: -10, type: "hole", rx: 5.5, ry: 4 },
-  l1:      { x: 16, y: 0,   type: "hole", rx: 5.5, ry: 4 },
-  l2:      { x: 26, y: 0,   type: "hole", rx: 5.5, ry: 4 },
-  l3:      { x: 36, y: 0,   type: "hole", rx: 5.5, ry: 4 },
-  r1:      { x: 48, y: 0,   type: "hole", rx: 5.5, ry: 4 },
-  r2:      { x: 58, y: 0,   type: "hole", rx: 5.5, ry: 4 },
-  r3:      { x: 68, y: 0,   type: "hole", rx: 5.5, ry: 4 },
-  eb:      { x: 72, y: 10,  type: "lever-right", width: 7, height: 3.5 },
-  gsharp:  { x: 78, y: -10, type: "lever-left",  width: 7, height: 3.5 },
-  c:       { x: 84, y: 0,   type: "hole", rx: 5, ry: 3.5 },
-  csharp:  { x: 88, y: 10,  type: "lever-right", width: 6, height: 3 },
-  b:       { x: 92, y: -10, type: "lever-left",  width: 6, height: 3 },
-  lowc:    { x: 97, y: 8,   type: "foot", width: 5, height: 4 },
-  lowcsharp:{ x: 97, y: -8,  type: "foot", width: 5, height: 4 },
-  lowd:    { x: 94, y: 0,   type: "hole", rx: 4.5, ry: 3.5 },
+// Ordered high->low: 3 subgroups of 3 holes each
+const HOLES: { y: number }[][] = [
+  [{ y: 152 }, { y: 170 }, { y: 188 }], // octave 3
+  [{ y: 206 }, { y: 224 }, { y: 242 }], // octave 2
+  [{ y: 260 }, { y: 278 }, { y: 296 }], // octave 1
+];
+
+const sharpToFlat = (note: Note): Note => SHARP_TO_FLAT[note] || note;
+
+const inScale = (n: Note, s: Scale) => getScaleNotes(s).includes(n);
+
+const noteColor = (
+  note: Note,
+  scale: Scale,
+  isRoot: boolean,
+  isDarkMode: boolean,
+  highlightRoots: boolean
+): string => {
+  if (isRoot) return isDarkMode ? "#f3f4f6" : "#000000";
+  if (highlightRoots) return isDarkMode ? "#60a5fa" : "#3b82f6";
+  const degree = getScaleDegree(note, scale);
+  const norm = ["♭2", "♭3", "♭5", "♭6", "♭7"].includes(degree)
+    ? degree.replace("♭", "")
+    : degree;
+  switch (norm) {
+    case "2": return isDarkMode ? "#059669" : "#047857";
+    case "3": return isDarkMode ? "#ea580c" : "#c2410c";
+    case "4": return isDarkMode ? "#34d399" : "#10b981";
+    case "5": return isDarkMode ? "#f97316" : "#ea580c";
+    case "6": return isDarkMode ? "#6ee7b7" : "#34d399";
+    case "7": return isDarkMode ? "#fb923c" : "#f97316";
+    default: return isDarkMode ? "#9ca3af" : "#6b7280";
+  }
 };
 
-/* ------------------------------------------------------------------ */
-
-export const FluteDiagram: React.FC<FluteDiagramProps> = ({
+export default function FluteDiagram({
   note,
   scale,
   displayMode,
   isDarkMode,
   highlightRoots,
   onPlay,
-}) => {
-  const [isFocused, setIsFocused] = React.useState(false);
-  const fingering = getFluteFingering(note);
+}: FluteDiagramProps) {
+  const raw = note.replace(/\d/, "") as Note;
+  const isRoot = raw === scale.root;
 
-  const match = note.match(/^([A-G][#b]?)(\d+)$/);
-  const noteName = match ? (match[1] as Note) : ("C" as Note);
-
-  const handleClick = () => onPlay(note);
-  const handleKeyDown = (e: React.KeyboardEvent<SVGGElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onPlay(note);
-    }
+  const handleClick = () => {
+    if (inScale(raw, scale)) onPlay(note);
   };
 
-  const closedFill = isDarkMode ? "#d1d5db" : "#1f2937";
-  const openStroke = isDarkMode ? "#9ca3af" : "#4b5563";
-  const tubeFill = isDarkMode ? "#374151" : "#e5e7eb";
-  const tubeStroke = isDarkMode ? "#6b7280" : "#9ca3af";
-  const leverFill = isDarkMode ? "#6b7280" : "#d1d5db";
-  const leverStroke = isDarkMode ? "#9ca3af" : "#6b7280";
-
-  const labelText = (() => {
-    if (displayMode === "degree") {
-      return getScaleDegree(noteName, scale);
-    }
-    if (displayMode === "flat") {
-      return sharpToFlat(noteName);
-    }
-    return noteName;
-  })();
-
-  const noteColor = getScaleNoteColor(noteName, scale, isDarkMode, highlightRoots);
-
-  /* helpers ---------------------------------------------------------- */
-  const keyState = (id: string) =>
-    fingering?.keys.find((k) => k.keyId === id);
-
-  const isClosed = (id: string) => keyState(id)?.closed ?? false;
-
-  const tubeLength = 260;
-  const tubeY = 50;
-  const tubeH = 24;
+  const label = () => {
+    if (displayMode === "degree") return getScaleDegree(raw, scale);
+    if (displayMode === "flat") return sharpToFlat(raw);
+    return raw;
+  };
 
   return (
-    <g
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      onFocus={() => setIsFocused(true)}
-      onBlur={() => setIsFocused(false)}
-      role="button"
-      tabIndex={0}
-      aria-label={`Play ${note} on flute`}
-      className="cursor-pointer focus:outline-none"
-      style={{ outline: "none" }}
-    >
-      {/* Focus outline */}
-      {isFocused && (
-        <rect
-          x={-8}
-          y={-14}
-          width={tubeLength + 56}
-          height={tubeH + 52}
-          rx={8}
-          fill="none"
-          stroke="#3b82f6"
-          strokeWidth={2.5}
-          className="transition-colors duration-200"
-        />
-      )}
-
-      {/* Note label */}
-      <text
-        x={tubeLength / 2 + 20}
-        y={-2}
-        textAnchor="middle"
-        dominantBaseline="middle"
-        fill={noteColor}
-        fontSize="15"
-        fontWeight="bold"
-        className="select-none"
-      >
-        {labelText}
-      </text>
-
-      {/* ====== FLUTE BODY ====== */}
-
-      {/* Main tube */}
+    <g>
+      {/* Body bg */}
       <rect
         x={0}
-        y={tubeY}
-        width={tubeLength}
-        height={tubeH}
-        rx={12}
-        fill={tubeFill}
-        stroke={tubeStroke}
-        strokeWidth={1}
+        y={0}
+        width={DIAGRAM_W}
+        height={DIAGRAM_H}
+        rx={14}
+        fill={isDarkMode ? "#374151" : "#e5e7eb"}
         className="transition-colors duration-200"
       />
 
-      {/* Embouchure hole (lip plate) */}
+      {/* Embouchure */}
       <ellipse
-        cx={14}
-        cy={tubeY + tubeH / 2}
-        rx={10}
+        cx={TUBE_CX}
+        cy={18}
+        rx={16}
         ry={7}
-        fill={isDarkMode ? "#1f2937" : "#f3f4f6"}
-        stroke={tubeStroke}
+        fill={isDarkMode ? "#1f2937" : "#ffffff"}
+        stroke={isDarkMode ? "#6b7280" : "#9ca3af"}
         strokeWidth={1}
       />
-      <ellipse
-        cx={14}
-        cy={tubeY + tubeH / 2}
-        rx={6}
-        ry={4}
-        fill={isDarkMode ? "#111827" : "#d1d5db"}
-      />
 
-      {/* Tenon joints (subtle rings) */}
-      <rect x={78} y={tubeY - 1} width={3} height={tubeH + 2} rx={1} fill={tubeStroke} opacity={0.5} />
-      <rect x={158} y={tubeY - 1} width={3} height={tubeH + 2} rx={1} fill={tubeStroke} opacity={0.5} />
-
-      {/* Foot joint end cap */}
+      {/* Tube */}
       <rect
-        x={tubeLength - 4}
-        y={tubeY + 2}
-        width={4}
-        height={tubeH - 4}
-        rx={2}
-        fill={tubeStroke}
-        opacity={0.6}
+        x={TUBE_X}
+        y={26}
+        width={TUBE_W}
+        height={236}
+        rx={12}
+        fill={isDarkMode ? "#6b7280" : "#d1d5db"}
+        stroke={isDarkMode ? "#1f2937" : "#ffffff"}
+        strokeWidth={1}
       />
 
-      {/* ====== KEYS ====== */}
+      {/* Tenon rings */}
+      <rect x={TUBE_X - 2} y={140} width={TUBE_W + 4} height={8} rx={3} fill={isDarkMode ? "#9ca3af" : "#ffffff"} />
+      <rect x={TUBE_X - 2} y={180} width={TUBE_W + 4} height={8} rx={3} fill={isDarkMode ? "#9ca3af" : "#ffffff"} />
 
-      {fingering?.keys.map((key) => {
-        const layout = KEY_LAYOUTS[key.keyId];
-        if (!layout) return null;
+      {/* Foot cap */}
+      <path
+        d={`M ${TUBE_X} 262 L ${TUBE_X + TUBE_W} 262 L ${TUBE_X + TUBE_W - 5} 296 Q ${TUBE_CX} 306 ${TUBE_X + 5} 296 Z`}
+        fill={isDarkMode ? "#6b7280" : "#b0b7c3"}
+      />
 
-        const kx = (layout.x / 100) * tubeLength;
-        const ky = tubeY + tubeH / 2 + layout.y;
-
-        if (layout.type === "hole") {
+      {/* Holes */}
+      {HOLES.map((row, ri) =>
+        row.map((hole, hi) => {
+          const hx = TUBE_CX + (hi - 1) * 9;
+          const hy = hole.y;
+          const active = inScale(raw, scale);
+          if (!active) return null;
+          const nr = isRoot;
           return (
-            <g key={key.keyId}>
-              {/* Pad cup (key surround) */}
-              <ellipse
-                cx={kx}
-                cy={ky}
-                rx={(layout.rx ?? 5) + 2}
-                ry={(layout.ry ?? 4) + 1.5}
-                fill={isDarkMode ? "#4b5563" : "#9ca3af"}
-                opacity={0.4}
+            <g key={`hole-${ri}-${hi}`} onClick={handleClick} className="cursor-pointer">
+              <circle
+                cx={hx}
+                cy={hy}
+                r={8}
+                fill={noteColor(raw, scale, nr, isDarkMode, highlightRoots)}
+                stroke={isDarkMode ? "#1f2937" : "#000000"}
+                strokeWidth={1}
               />
-              {/* Hole */}
-              <ellipse
-                cx={kx}
-                cy={ky}
-                rx={layout.rx ?? 5}
-                ry={layout.ry ?? 4}
-                fill={key.closed ? closedFill : "none"}
-                stroke={openStroke}
-                strokeWidth={1.8}
-                className="transition-colors duration-200"
-              />
+              <text
+                x={hx}
+                y={hy}
+                textAnchor="middle"
+                dominantBaseline="middle"
+                fill={isDarkMode ? "#1f2937" : nr ? "#ffffff" : "#1f2937"}
+                fontSize="9"
+                className="select-none font-bold"
+              >
+                {label()}
+              </text>
             </g>
           );
-        }
+        })
+      )}
 
-        /* lever or foot key */
-        const lw = layout.width ?? 6;
-        const lh = layout.height ?? 3;
+      {/* Keys */}
+      {KEYS.map((k) => {
+        const active = inScale(raw, scale);
+        if (!active) return null;
         return (
-          <g key={key.keyId}>
-            {/* Lever arm */}
-            <line
-              x1={kx}
-              y1={tubeY + tubeH / 2}
-              x2={kx}
-              y2={ky}
-              stroke={leverStroke}
-              strokeWidth={1.2}
-              opacity={0.6}
-            />
-            {/* Lever pad */}
+          <g key={k.name} onClick={handleClick} className="cursor-pointer">
             <rect
-              x={kx - lw / 2}
-              y={ky - lh / 2}
-              width={lw}
-              height={lh}
-              rx={1.5}
-              fill={key.closed ? closedFill : leverFill}
-              stroke={openStroke}
-              strokeWidth={1.5}
-              className="transition-colors duration-200"
+              x={k.x - k.w / 2}
+              y={k.y}
+              width={k.w}
+              height={k.h}
+              rx={k.r}
+              fill={isDarkMode ? "#4b5563" : "#ffffff"}
+              stroke={isDarkMode ? "#1f2937" : "#000000"}
+              strokeWidth={1}
             />
-          </g>
-        );
-      })}
-
-      {/* ====== KEY LABELS (mini legend below) ====== */}
-      <g transform={`translate(0, ${tubeY + tubeH + 14})`}>
-        {fingering?.keys.map((key, i) => {
-          const layout = KEY_LAYOUTS[key.keyId];
-          if (!layout) return null;
-          const kx = (layout.x / 100) * tubeLength;
-          return (
             <text
-              key={`label-${key.keyId}`}
-              x={kx}
-              y={0}
+              x={k.x}
+              y={k.y + k.h / 2 + k.labelDy}
               textAnchor="middle"
               dominantBaseline="middle"
-              fill={isDarkMode ? "#9ca3af" : "#4b5563"}
+              fill={isDarkMode ? "#e5e7eb" : "#374151"}
               fontSize="7"
               className="select-none"
             >
-              {key.label}
+              {k.name.replace("_", " ")}
             </text>
-          );
-        })}
-      </g>
+          </g>
+        );
+      })}
     </g>
   );
-};
+}

--- a/src/app/flute/page.tsx
+++ b/src/app/flute/page.tsx
@@ -17,9 +17,9 @@ import ChordPanel from "@/components/ChordPanel/ChordPanel";
 import PatternPanel from "@/components/PatternPanel/PatternPanel";
 
 const NOTE_COUNT_OPTIONS = [1, 3, 5, 7, 12, 24];
-const DIAGRAM_WIDTH = 340;
-const GAP = 16;
-const PADDING = 24;
+const DIAGRAM_WIDTH = 344;
+const ROW_GAP = 18;
+const PADDING_X = 12;
 
 const getNoteCount = (): number => {
   const saved = localStorage.getItem("flute-note-count");
@@ -52,27 +52,23 @@ export default function Flute() {
 
   const displayMode = showDegrees ? "degree" : showFlats ? "flat" : "note";
 
-  const totalWidth = notes.length * DIAGRAM_WIDTH + (notes.length - 1) * GAP + PADDING * 2;
-  const viewBox = `0 0 ${totalWidth} 140`;
-
   return (
     <div className="w-full space-y-6">
-      <div className="w-full overflow-x-auto">
-        <svg
-          width="100%"
-          height="140"
-          viewBox={viewBox}
-          className={`border rounded-lg transition-colors duration-200 ${
-            isDarkMode
-              ? "border-gray-700 bg-gray-800"
-              : "border-slate-400 bg-slate-300"
-          }`}
-        >
-          {notes.map((note, i) => (
-            <g
-              key={`${note}-${i}`}
-              transform={`translate(${PADDING + i * (DIAGRAM_WIDTH + GAP)}, 12)`}
-            >
+      <div className="w-full flex flex-col gap-5">
+        {notes.map((note, i) => (
+          <svg
+            key={`${note}-${i}`}
+            width="100%"
+            height="130"
+            viewBox={`0 0 ${DIAGRAM_WIDTH + PADDING_X * 2} 130`}
+            preserveAspectRatio="xMidYMid meet"
+            className={`border rounded-lg transition-colors duration-200 ${
+              isDarkMode
+                ? "border-gray-700 bg-gray-800"
+                : "border-slate-400 bg-slate-300"
+            }`}
+          >
+            <g transform={`translate(${PADDING_X}, 10)`}>
               <FluteDiagram
                 note={note}
                 scale={scale}
@@ -82,8 +78,8 @@ export default function Flute() {
                 onPlay={playNoteSound}
               />
             </g>
-          ))}
-        </svg>
+          </svg>
+        ))}
       </div>
 
       <ChordPanel scale={scale} />

--- a/src/app/flute/page.tsx
+++ b/src/app/flute/page.tsx
@@ -13,6 +13,8 @@ import { NoteWithOctave } from "@/lib/utils/note";
 import { usePlayNote } from "@/lib/hooks/usePlayNote";
 import { getConsecutiveScaleNotes } from "@/lib/utils/fluteUtils";
 import { FluteDiagram } from "./FluteDiagram";
+import ChordPanel from "@/components/ChordPanel/ChordPanel";
+import PatternPanel from "@/components/PatternPanel/PatternPanel";
 
 const NOTE_COUNT_OPTIONS = [1, 3, 5, 7, 12, 24];
 const DIAGRAM_WIDTH = 340;
@@ -83,6 +85,9 @@ export default function Flute() {
           ))}
         </svg>
       </div>
+
+      <ChordPanel scale={scale} />
+      <PatternPanel scale={scale} />
 
       <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-gray-700">
         <div className="flex flex-col gap-1">

--- a/src/app/flute/page.tsx
+++ b/src/app/flute/page.tsx
@@ -15,9 +15,9 @@ import { getConsecutiveScaleNotes } from "@/lib/utils/fluteUtils";
 import { FluteDiagram } from "./FluteDiagram";
 
 const NOTE_COUNT_OPTIONS = [1, 3, 5, 7, 12, 24];
-const DIAGRAM_WIDTH = 80;
-const GAP = 20;
-const PADDING = 20;
+const DIAGRAM_WIDTH = 340;
+const GAP = 16;
+const PADDING = 24;
 
 const getNoteCount = (): number => {
   const saved = localStorage.getItem("flute-note-count");
@@ -51,14 +51,14 @@ export default function Flute() {
   const displayMode = showDegrees ? "degree" : showFlats ? "flat" : "note";
 
   const totalWidth = notes.length * DIAGRAM_WIDTH + (notes.length - 1) * GAP + PADDING * 2;
-  const viewBox = `0 0 ${totalWidth} 400`;
+  const viewBox = `0 0 ${totalWidth} 140`;
 
   return (
     <div className="w-full space-y-6">
       <div className="w-full overflow-x-auto">
         <svg
           width="100%"
-          height="400"
+          height="140"
           viewBox={viewBox}
           className={`border rounded-lg transition-colors duration-200 ${
             isDarkMode
@@ -69,7 +69,7 @@ export default function Flute() {
           {notes.map((note, i) => (
             <g
               key={`${note}-${i}`}
-              transform={`translate(${PADDING + i * (DIAGRAM_WIDTH + GAP) + DIAGRAM_WIDTH / 2}, 20)`}
+              transform={`translate(${PADDING + i * (DIAGRAM_WIDTH + GAP)}, 12)`}
             >
               <FluteDiagram
                 note={note}

--- a/src/app/flute/page.tsx
+++ b/src/app/flute/page.tsx
@@ -12,14 +12,15 @@ import {
 import { NoteWithOctave } from "@/lib/utils/note";
 import { usePlayNote } from "@/lib/hooks/usePlayNote";
 import { getConsecutiveScaleNotes } from "@/lib/utils/fluteUtils";
-import { FluteDiagram } from "./FluteDiagram";
+import FluteDiagram from "./FluteDiagram";
 import ChordPanel from "@/components/ChordPanel/ChordPanel";
 import PatternPanel from "@/components/PatternPanel/PatternPanel";
 
 const NOTE_COUNT_OPTIONS = [1, 3, 5, 7, 12, 24];
-const DIAGRAM_WIDTH = 344;
-const ROW_GAP = 18;
-const PADDING_X = 12;
+const DIAGRAM_WIDTH = 124;
+const DIAGRAM_HEIGHT = 320;
+const GAP = 18;
+const PADDING = 16;
 
 const getNoteCount = (): number => {
   const saved = localStorage.getItem("flute-note-count");
@@ -52,23 +53,27 @@ export default function Flute() {
 
   const displayMode = showDegrees ? "degree" : showFlats ? "flat" : "note";
 
+  const totalWidth = notes.length * DIAGRAM_WIDTH + (notes.length - 1) * GAP + PADDING * 2;
+  const viewBox = `0 0 ${totalWidth} ${DIAGRAM_HEIGHT}`;
+
   return (
     <div className="w-full space-y-6">
-      <div className="w-full flex flex-col gap-5">
-        {notes.map((note, i) => (
-          <svg
-            key={`${note}-${i}`}
-            width="100%"
-            height="130"
-            viewBox={`0 0 ${DIAGRAM_WIDTH + PADDING_X * 2} 130`}
-            preserveAspectRatio="xMidYMid meet"
-            className={`border rounded-lg transition-colors duration-200 ${
-              isDarkMode
-                ? "border-gray-700 bg-gray-800"
-                : "border-slate-400 bg-slate-300"
-            }`}
-          >
-            <g transform={`translate(${PADDING_X}, 10)`}>
+      <div className="w-full overflow-x-auto">
+        <svg
+          width="100%"
+          height={DIAGRAM_HEIGHT}
+          viewBox={viewBox}
+          className={`border rounded-lg transition-colors duration-200 ${
+            isDarkMode
+              ? "border-gray-700 bg-gray-800"
+              : "border-slate-400 bg-slate-300"
+          }`}
+        >
+          {notes.map((note, i) => (
+            <g
+              key={`${note}-${i}`}
+              transform={`translate(${PADDING + i * (DIAGRAM_WIDTH + GAP)}, 8)`}
+            >
               <FluteDiagram
                 note={note}
                 scale={scale}
@@ -78,8 +83,8 @@ export default function Flute() {
                 onPlay={playNoteSound}
               />
             </g>
-          </svg>
-        ))}
+          ))}
+        </svg>
       </div>
 
       <ChordPanel scale={scale} />

--- a/src/app/harmonica/page.tsx
+++ b/src/app/harmonica/page.tsx
@@ -18,6 +18,8 @@ import {
   selectShowDegrees,
 } from "../../features/globalConfig/globalConfigSlice";
 import { Note, NoteWithOctave } from "@/lib/utils/note";
+import ChordPanel from "@/components/ChordPanel/ChordPanel";
+import PatternPanel from "@/components/PatternPanel/PatternPanel";
 
 // Common harmonica keys
 const HARMONICA_KEYS: Note[] = ["C", "G", "A", "D", "F", "Bb", "Eb"];
@@ -267,6 +269,10 @@ export default function Harmonica() {
           })}
         </svg>
       </div>
+
+      <ChordPanel scale={scale} />
+      <PatternPanel scale={scale} />
+
       <div className="flex justify-end mt-2">
         <div className="flex flex-col gap-1">
           <label

--- a/src/app/kalimba/page.tsx
+++ b/src/app/kalimba/page.tsx
@@ -15,6 +15,8 @@ import {
   selectShowDegrees,
 } from "../../features/globalConfig/globalConfigSlice";
 import { Note, NoteWithOctave } from "@/lib/utils/note";
+import ChordPanel from "@/components/ChordPanel/ChordPanel";
+import PatternPanel from "@/components/PatternPanel/PatternPanel";
 
 // Standard 17-key kalimba scaleRoot (from center outward)
 const KALIMBA_NOTES: Note[] = [
@@ -200,6 +202,9 @@ export default function Kalimba() {
           );
         })}
       </svg>
+
+      <ChordPanel scale={scale} />
+      <PatternPanel scale={scale} />
     </div>
   );
 }


### PR DESCRIPTION
## Flute view rework

Redessine la vue flûte traversière avec un diagramme horizontal réaliste.

- Corps de flûte horizontal avec embouchure, tenons et pied
- Clés positionnées le long du tube avec espacement réaliste (Boehm)
- Trous de tonalité avec pad cups ; leviers avec bras
- Labels mini sous chaque clé
- Ajustement de la page pour diagrammes horizontaux (340×140)

## Cross-instrument parity

`ChordPanel` et `PatternPanel` sont maintenant exposés sur **tous** les instruments :
- Flute (nouveau)
- Harmonica (nouveau)
- Kalimba (nouveau)
- Guitar (déjà présent)
- Piano (déjà présent)

## Verification

- Build passing localement : `npm run build`
- Branche : `feat/rework-flute-view`
- 2 commits, 3 fichiers modifiés