### PR TITLE
Feat/flute diagram redesign

### DIFF
--- a/src/__tests__/unit/flute/FlutePage.test.tsx
+++ b/src/__tests__/unit/flute/FlutePage.test.tsx
@@ -3,47 +3,31 @@
  */
 
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import { Provider } from "react-redux";
-import { configureStore } from "@reduxjs/toolkit";
+import { screen, fireEvent } from "@testing-library/react";
 import Flute from "@/app/flute/page";
-import globalConfigReducer from "@/features/globalConfig/globalConfigSlice";
-import audioReducer from "@/features/audio/audioSlice";
+import { renderWithProviders } from "@/__tests__/test-utils";
 
-function createTestStore() {
-  return configureStore({
-    reducer: {
-      globalConfig: globalConfigReducer,
-      audio: audioReducer,
-    },
-  });
-}
-
-function renderWithProviders(ui: React.ReactElement) {
-  const store = createTestStore();
-  return render(<Provider store={store}>{ui}</Provider>);
-}
+// Scope to the flute fingering diagrams; the Chord/Pattern panels also
+// render buttons, so match on their "…on flute" aria-label.
+const getDiagrams = () => screen.getAllByRole("button", { name: /on flute$/ });
 
 describe("FlutePage (T015)", () => {
   it("renders 7 diagrams by default", () => {
     renderWithProviders(<Flute />);
-    const diagrams = screen.getAllByRole("button");
-    expect(diagrams).toHaveLength(7);
+    expect(getDiagrams()).toHaveLength(7);
   });
 
   it("updates to 12 diagrams when note count changes to 12", () => {
     renderWithProviders(<Flute />);
     const select = screen.getByLabelText("Select number of notes to display");
     fireEvent.change(select, { target: { value: "12" } });
-    const diagrams = screen.getAllByRole("button");
-    expect(diagrams).toHaveLength(12);
+    expect(getDiagrams()).toHaveLength(12);
   });
 
   it("updates to 3 diagrams when note count changes to 3", () => {
     renderWithProviders(<Flute />);
     const select = screen.getByLabelText("Select number of notes to display");
     fireEvent.change(select, { target: { value: "3" } });
-    const diagrams = screen.getAllByRole("button");
-    expect(diagrams).toHaveLength(3);
+    expect(getDiagrams()).toHaveLength(3);
   });
 });

--- a/src/app/flute/FluteDiagram.tsx
+++ b/src/app/flute/FluteDiagram.tsx
@@ -14,6 +14,8 @@ export interface FluteDiagramProps {
   isDarkMode: boolean;
   highlightRoots: boolean;
   onPlay: (note: NoteWithOctave) => void;
+  /** Optional chord/pattern highlight override applied to the note label color. */
+  getHighlightColor?: (noteName: Note, fallback: string) => string;
 }
 
 const sharpToFlat = (note: Note): Note => {
@@ -59,6 +61,7 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   isDarkMode,
   highlightRoots,
   onPlay,
+  getHighlightColor,
 }) => {
   const [isFocused, setIsFocused] = React.useState(false);
   const gradientId = React.useId();
@@ -100,7 +103,10 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
     return noteName;
   })();
 
-  const noteColor = getScaleNoteColor(noteName, scale, isDarkMode, highlightRoots);
+  const baseNoteColor = getScaleNoteColor(noteName, scale, isDarkMode, highlightRoots);
+  const noteColor = getHighlightColor
+    ? getHighlightColor(noteName, baseNoteColor)
+    : baseNoteColor;
 
   return (
     <g

--- a/src/app/flute/FluteDiagram.tsx
+++ b/src/app/flute/FluteDiagram.tsx
@@ -20,6 +20,15 @@ const sharpToFlat = (note: Note): Note => {
   return SHARP_TO_FLAT[note] || note;
 };
 
+// Vertical layout of a single flute column (kept aligned with page.tsx spacing)
+const TUBE_X = -16;
+const TUBE_WIDTH = 32;
+const TUBE_TOP = 40;
+const TUBE_HEIGHT = 310;
+const EMBOUCHURE_Y = 56;
+const FIRST_KEY_Y = 78;
+const KEY_SPACING = 17;
+
 export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   note,
   scale,
@@ -29,6 +38,7 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   onPlay,
 }) => {
   const [isFocused, setIsFocused] = React.useState(false);
+  const gradientId = React.useId();
   const fingering = getFluteFingering(note);
 
   // Extract note name and octave
@@ -45,9 +55,17 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
     }
   };
 
-  const closedFill = isDarkMode ? "#d1d5db" : "#1f2937";
-  const openStroke = isDarkMode ? "#d1d5db" : "#1f2937";
-  const bodyFill = isDarkMode ? "#4b5563" : "#d1d5db";
+  // Metallic tube shading
+  const tubeStops = isDarkMode
+    ? ["#6b7280", "#374151", "#1f2937", "#374151", "#6b7280"]
+    : ["#f8fafc", "#cbd5e1", "#94a3b8", "#cbd5e1", "#f1f5f9"];
+  const tubeStroke = isDarkMode ? "#111827" : "#94a3b8";
+
+  // Key cups: closed = filled (pressed), open = hollow ring
+  const closedFill = isDarkMode ? "#e5e7eb" : "#1f2937";
+  const openFill = isDarkMode ? "#111827" : "#ffffff";
+  const ringStroke = isDarkMode ? "#9ca3af" : "#475569";
+  const embouchureFill = isDarkMode ? "#0b0f19" : "#334155";
 
   const labelText = (() => {
     if (displayMode === "degree") {
@@ -73,13 +91,26 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
       className="cursor-pointer focus:outline-none"
       style={{ outline: "none" }}
     >
+      <defs>
+        {/* Left-to-right silver shading gives the tube a rounded, metallic look */}
+        <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+          {tubeStops.map((color, i) => (
+            <stop
+              key={i}
+              offset={`${(i / (tubeStops.length - 1)) * 100}%`}
+              stopColor={color}
+            />
+          ))}
+        </linearGradient>
+      </defs>
+
       {/* Focus ring */}
       {isFocused && (
         <rect
           x={-36}
           y={0}
           width={72}
-          height={350}
+          height={360}
           rx={6}
           fill="none"
           stroke="#3b82f6"
@@ -91,7 +122,7 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
       {/* Note label above flute body */}
       <text
         x={0}
-        y={20}
+        y={18}
         textAnchor="middle"
         dominantBaseline="middle"
         fill={noteColor}
@@ -100,44 +131,56 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
         className="select-none"
       >
         {labelText}
+        {octave !== startOctave && (
+          <tspan fontSize="10" dy={-6} fill={isDarkMode ? "#9ca3af" : "#6b7280"}>
+            {octave}
+          </tspan>
+        )}
       </text>
 
-      {/* Octave indicator when different from starting octave */}
-      {octave !== startOctave && (
-        <text
-          x={0}
-          y={36}
-          textAnchor="middle"
-          dominantBaseline="middle"
-          fill={isDarkMode ? "#9ca3af" : "#6b7280"}
-          fontSize="10"
-          className="select-none"
-        >
-          {octave}
-        </text>
-      )}
-
-      {/* Flute body */}
+      {/* Flute tube (headjoint → foot), drawn as a rounded metallic pipe */}
       <rect
-        x={-30}
-        y={44}
-        width={60}
-        height={300}
-        rx={4}
-        fill={bodyFill}
+        x={TUBE_X}
+        y={TUBE_TOP}
+        width={TUBE_WIDTH}
+        height={TUBE_HEIGHT}
+        rx={TUBE_WIDTH / 2}
+        fill={`url(#${gradientId})`}
+        stroke={tubeStroke}
+        strokeWidth={1}
         className="transition-colors duration-200"
       />
+      {/* Specular highlight down the length of the tube */}
+      <rect
+        x={TUBE_X + 5}
+        y={TUBE_TOP + 4}
+        width={4}
+        height={TUBE_HEIGHT - 8}
+        rx={2}
+        fill={isDarkMode ? "#9ca3af" : "#ffffff"}
+        opacity={0.5}
+      />
 
-      {/* Key holes */}
+      {/* Embouchure hole (lip plate) on the headjoint */}
+      <ellipse
+        cx={0}
+        cy={EMBOUCHURE_Y}
+        rx={11}
+        ry={7}
+        fill={embouchureFill}
+        stroke={ringStroke}
+        strokeWidth={1.5}
+      />
+
+      {/* Key cups: filled = closed/pressed, hollow = open */}
       {fingering?.keys.map((key, i) => (
-        <g key={key.keyId} transform={`translate(0, ${60 + i * 18})`}>
-          <circle
-            r={8}
-            fill={key.closed ? closedFill : "none"}
-            stroke={openStroke}
-            strokeWidth={2}
-            className="transition-colors duration-200"
-          />
+        <g key={key.keyId} transform={`translate(0, ${FIRST_KEY_Y + i * KEY_SPACING})`}>
+          {/* Key ring seat */}
+          <circle r={8.5} fill={openFill} stroke={ringStroke} strokeWidth={1.5} />
+          {/* Closed indicator fills the cup */}
+          {key.closed && (
+            <circle r={5.5} fill={closedFill} className="transition-colors duration-200" />
+          )}
           {/* Key label */}
           <text
             x={20}

--- a/src/app/flute/FluteDiagram.tsx
+++ b/src/app/flute/FluteDiagram.tsx
@@ -28,6 +28,29 @@ const TUBE_HEIGHT = 310;
 const EMBOUCHURE_Y = 56;
 const FIRST_KEY_Y = 78;
 const KEY_SPACING = 17;
+const LABEL_X = 24;
+
+// Lateral offset (tube-local x) per key so cups sit where they physically are
+// on a Boehm flute instead of all stacked on the centerline: the six main
+// finger holes stay near the center line (with the L3 "offset-G" nudge), while
+// the thumb key and the pinky/foot levers protrude out to alternating sides.
+const KEY_OFFSET_X: Record<string, number> = {
+  thumb: -12,
+  l1: 0,
+  l2: 0,
+  l3: -8,
+  r1: 0,
+  r2: 0,
+  r3: 0,
+  eb: 13,
+  gsharp: -13,
+  c: 12,
+  csharp: 14,
+  b: -13,
+  lowc: 12,
+  lowcsharp: -12,
+  lowd: 14,
+};
 
 export const FluteDiagram: React.FC<FluteDiagramProps> = ({
   note,
@@ -173,27 +196,47 @@ export const FluteDiagram: React.FC<FluteDiagramProps> = ({
       />
 
       {/* Key cups: filled = closed/pressed, hollow = open */}
-      {fingering?.keys.map((key, i) => (
-        <g key={key.keyId} transform={`translate(0, ${FIRST_KEY_Y + i * KEY_SPACING})`}>
-          {/* Key ring seat */}
-          <circle r={8.5} fill={openFill} stroke={ringStroke} strokeWidth={1.5} />
-          {/* Closed indicator fills the cup */}
-          {key.closed && (
-            <circle r={5.5} fill={closedFill} className="transition-colors duration-200" />
-          )}
-          {/* Key label */}
-          <text
-            x={20}
-            y={0}
-            dominantBaseline="middle"
-            fill={isDarkMode ? "#d1d5db" : "#374151"}
-            fontSize="9"
-            className="select-none"
-          >
-            {key.label}
-          </text>
-        </g>
-      ))}
+      {fingering?.keys.map((key, i) => {
+        const y = FIRST_KEY_Y + i * KEY_SPACING;
+        const dx = KEY_OFFSET_X[key.keyId] ?? 0;
+        return (
+          <g key={key.keyId} transform={`translate(0, ${y})`}>
+            {/* Post connecting an offset key back to the tube body */}
+            {dx !== 0 && (
+              <line
+                x1={0}
+                y1={0}
+                x2={dx}
+                y2={0}
+                stroke={ringStroke}
+                strokeWidth={2}
+              />
+            )}
+            {/* Key ring seat */}
+            <circle cx={dx} r={8.5} fill={openFill} stroke={ringStroke} strokeWidth={1.5} />
+            {/* Closed indicator fills the cup */}
+            {key.closed && (
+              <circle
+                cx={dx}
+                r={5.5}
+                fill={closedFill}
+                className="transition-colors duration-200"
+              />
+            )}
+            {/* Key label kept in a fixed gutter so labels stay aligned */}
+            <text
+              x={LABEL_X}
+              y={0}
+              dominantBaseline="middle"
+              fill={isDarkMode ? "#d1d5db" : "#374151"}
+              fontSize="9"
+              className="select-none"
+            >
+              {key.label}
+            </text>
+          </g>
+        );
+      })}
     </g>
   );
 };

--- a/src/app/flute/page.tsx
+++ b/src/app/flute/page.tsx
@@ -9,10 +9,14 @@ import {
   selectIsMonochrome,
   selectShowDegrees,
 } from "@/features/globalConfig/globalConfigSlice";
-import { NoteWithOctave } from "@/lib/utils/note";
+import { Note, NoteWithOctave } from "@/lib/utils/note";
 import { usePlayNote } from "@/lib/hooks/usePlayNote";
 import { getConsecutiveScaleNotes } from "@/lib/utils/fluteUtils";
 import { FluteDiagram } from "./FluteDiagram";
+import ChordPanel from "@/components/ChordPanel/ChordPanel";
+import PatternPanel from "@/components/PatternPanel/PatternPanel";
+import { useChordHighlight } from "@/lib/hooks/useChordHighlight";
+import { usePatternHighlight } from "@/lib/hooks/usePatternHighlight";
 
 const NOTE_COUNT_OPTIONS = [1, 3, 5, 7, 12, 24];
 const DIAGRAM_WIDTH = 80;
@@ -37,6 +41,19 @@ export default function Flute() {
   const showDegrees = useSelector(selectShowDegrees);
   const highlightRoots = useSelector(selectIsMonochrome);
   const playNoteSound = usePlayNote();
+  const { getChordNoteColor, chordScaleMode, selectedChord } = useChordHighlight(scale);
+  const { getPatternNoteColor, isPatternModeEnabled } = usePatternHighlight(scale);
+
+  const getFinalNoteColor = (noteName: Note, fallback: string): string => {
+    if (isPatternModeEnabled) {
+      const patternColor = getPatternNoteColor(noteName, fallback);
+      if (patternColor !== fallback) return patternColor;
+    }
+    if (chordScaleMode && selectedChord) {
+      return getChordNoteColor(noteName, fallback);
+    }
+    return fallback;
+  };
 
   const [noteCount, setNoteCount] = useState<number>(getNoteCount);
 
@@ -78,11 +95,15 @@ export default function Flute() {
                 isDarkMode={isDarkMode}
                 highlightRoots={highlightRoots}
                 onPlay={playNoteSound}
+                getHighlightColor={getFinalNoteColor}
               />
             </g>
           ))}
         </svg>
       </div>
+
+      <ChordPanel scale={scale} />
+      <PatternPanel scale={scale} />
 
       <div className="flex justify-end pt-4 border-t border-gray-200 dark:border-gray-700">
         <div className="flex flex-col gap-1">

--- a/src/app/harmonica/page.tsx
+++ b/src/app/harmonica/page.tsx
@@ -18,6 +18,10 @@ import {
   selectShowDegrees,
 } from "../../features/globalConfig/globalConfigSlice";
 import { Note, NoteWithOctave } from "@/lib/utils/note";
+import ChordPanel from "@/components/ChordPanel/ChordPanel";
+import PatternPanel from "@/components/PatternPanel/PatternPanel";
+import { useChordHighlight } from "@/lib/hooks/useChordHighlight";
+import { usePatternHighlight } from "@/lib/hooks/usePatternHighlight";
 
 // Common harmonica keys
 const HARMONICA_KEYS: Note[] = ["C", "G", "A", "D", "F", "Bb", "Eb"];
@@ -56,6 +60,19 @@ export default function Harmonica() {
   const playNoteSound = usePlayNote();
   const [selectedKey, setSelectedKey] = useState<Note>("C");
   const harmonicaNotes = transposeHarmonicaNotes(selectedKey);
+  const { getChordNoteColor, chordScaleMode, selectedChord } = useChordHighlight(scale);
+  const { getPatternNoteColor, isPatternModeEnabled } = usePatternHighlight(scale);
+
+  const getFinalNoteColor = (note: Note, fallback: string): string => {
+    if (isPatternModeEnabled) {
+      const patternColor = getPatternNoteColor(note, fallback);
+      if (patternColor !== fallback) return patternColor;
+    }
+    if (chordScaleMode && selectedChord) {
+      return getChordNoteColor(note, fallback);
+    }
+    return fallback;
+  };
 
   const getNoteColor = (note: Note, isRoot: boolean): string => {
     if (isRoot) {
@@ -108,7 +125,7 @@ export default function Harmonica() {
   };
 
   return (
-    <div className="w-full">
+    <div className="w-full space-y-6">
       <div className="w-full overflow-x-auto">
         <svg
           width="100%"
@@ -164,7 +181,7 @@ export default function Harmonica() {
                       cx={x}
                       cy="130"
                       r="22"
-                      fill={getNoteColor(blowNote, isBlowRoot)}
+                      fill={getFinalNoteColor(blowNote, getNoteColor(blowNote, isBlowRoot))}
                       className="transition-colors duration-200 hover:fill-opacity-90"
                     />
                     <text
@@ -212,7 +229,7 @@ export default function Harmonica() {
                       cx={x}
                       cy="270"
                       r="22"
-                      fill={getNoteColor(drawNote, isDrawRoot)}
+                      fill={getFinalNoteColor(drawNote, getNoteColor(drawNote, isDrawRoot))}
                       className="transition-colors duration-200 hover:fill-opacity-90"
                     />
                     <text
@@ -267,6 +284,10 @@ export default function Harmonica() {
           })}
         </svg>
       </div>
+
+      <ChordPanel scale={scale} />
+      <PatternPanel scale={scale} />
+
       <div className="flex justify-end mt-2">
         <div className="flex flex-col gap-1">
           <label

--- a/src/app/kalimba/page.tsx
+++ b/src/app/kalimba/page.tsx
@@ -15,6 +15,10 @@ import {
   selectShowDegrees,
 } from "../../features/globalConfig/globalConfigSlice";
 import { Note, NoteWithOctave } from "@/lib/utils/note";
+import ChordPanel from "@/components/ChordPanel/ChordPanel";
+import PatternPanel from "@/components/PatternPanel/PatternPanel";
+import { useChordHighlight } from "@/lib/hooks/useChordHighlight";
+import { usePatternHighlight } from "@/lib/hooks/usePatternHighlight";
 
 // Standard 17-key kalimba scaleRoot (from center outward)
 const KALIMBA_NOTES: Note[] = [
@@ -48,6 +52,19 @@ export default function Kalimba() {
   const showDegrees = useSelector(selectShowDegrees);
   const highlightRoots = useSelector(selectIsMonochrome);
   const playNoteSound = usePlayNote();
+  const { getChordNoteColor, chordScaleMode, selectedChord } = useChordHighlight(scale);
+  const { getPatternNoteColor, isPatternModeEnabled } = usePatternHighlight(scale);
+
+  const getFinalNoteColor = (note: Note, fallback: string): string => {
+    if (isPatternModeEnabled) {
+      const patternColor = getPatternNoteColor(note, fallback);
+      if (patternColor !== fallback) return patternColor;
+    }
+    if (chordScaleMode && selectedChord) {
+      return getChordNoteColor(note, fallback);
+    }
+    return fallback;
+  };
 
   const getNoteColor = (note: Note, isRoot: boolean): string => {
     if (isRoot) {
@@ -97,11 +114,12 @@ export default function Kalimba() {
   };
 
   return (
-    <div className="w-full overflow-x-auto">
-      <svg
-        width="100%"
-        height="400"
-        viewBox="0 0 800 400"
+    <div className="w-full space-y-6">
+      <div className="w-full overflow-x-auto">
+        <svg
+          width="100%"
+          height="400"
+          viewBox="0 0 800 400"
         className={`border rounded-lg transition-colors duration-200 ${
           isDarkMode
             ? "border-gray-700 bg-gray-800"
@@ -155,7 +173,7 @@ export default function Kalimba() {
                 >
                   <circle
                     r={15}
-                    fill={getNoteColor(note, isRoot)}
+                    fill={getFinalNoteColor(note, getNoteColor(note, isRoot))}
                     className="transition-colors duration-200 hover:fill-opacity-90"
                   />
                   <text
@@ -199,7 +217,11 @@ export default function Kalimba() {
             </g>
           );
         })}
-      </svg>
+        </svg>
+      </div>
+
+      <ChordPanel scale={scale} />
+      <PatternPanel scale={scale} />
     </div>
   );
 }


### PR DESCRIPTION
Suggested title:

▎ Flute diagram redesign + Chord/Pattern panels on all instruments

The branch feat/flute-diagram-redesign is pushed and ready, with three commits:
- ea9dbb1 — redesign flute diagram to look like a transverse flute
- 6e494a7 — stagger key cups to match real flute key placement
- 5620c21 — add Chord and Pattern panels to kalimba, harmonica, flute

Status: 181 tests pass, tsc clean, and /flute, /kalimba, /harmonica all serve 200. The commit is clean — the unrelated specs/008-Microsoft-Market/ file is left untracked, not committed.