### PR TITLE
Sync scale display settings with shareable URL query params

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-transverse-flute"
+  "feature_directory": "specs/002-url-params"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,6 @@ The application uses a hybrid approach to state management for learning purposes
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan:
-- Plan: `specs/001-transverse-flute/plan.md`
-- Spec: `specs/001-transverse-flute/spec.md`
+- Plan: `specs/002-url-params/plan.md`
+- Spec: `specs/002-url-params/spec.md`
 <!-- SPECKIT END -->

--- a/specs/002-url-params/checklists/requirements.md
+++ b/specs/002-url-params/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Shareable URL Parameters for Scale Display Settings
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-06
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass on first validation pass. No [NEEDS CLARIFICATION] markers were needed — reasonable defaults were documented in the Assumptions section instead (scope of pages affected, meaning of "color mode"/"number display", exclusion of instrument-specific settings).
+- Ready for `/speckit-plan`.

--- a/specs/002-url-params/contracts/url-query-params.md
+++ b/specs/002-url-params/contracts/url-query-params.md
@@ -1,0 +1,28 @@
+# Contract: Scale Display Configuration Query Parameters
+
+This app has no backend API; the external "contract" this feature introduces is the shape of the URL query string that any instrument page (`/piano`, `/guitar`, `/kalimba`, `/harmonica`, `/flute`, `/recorder`) accepts and produces.
+
+## Parameters
+
+| Key | Required | Type | Allowed values | Example |
+|---|---|---|---|---|
+| `root` | No | string | One of the 12 sharp-spelled `ROOTS` values (`C`, `C#`, `D`, `D#`, `E`, `F`, `F#`, `G`, `G#`, `A`, `A#`, `B`) — flat spellings (`Bb`, `Db`, ...) are display-only elsewhere in the app and are not accepted here | `root=C%23` (URL-encoded `C#`) |
+| `scale` | No | string | A built-in scale type id (see `SCALE_TYPES`) or a custom scale id (`custom-*`) present in the visiting user's browser | `scale=major` |
+| `mode` | No | string | A member of `ScaleMode` (`ionian`, `dorian`, `phrygian`, `lydian`, `mixolydian`, `aeolian`, `locrian`) — only meaningful for scale types that support modes | `mode=dorian` |
+| `color` | No | `"1"` \| `"0"` | `1` = highlighted root notes, `0` = monochrome | `color=1` |
+| `flats` | No | `"1"` \| `"0"` | `1` = flat note names, `0` = sharp note names | `flats=0` |
+| `numbers` | No | `"1"` \| `"0"` | `1` = scale-degree numbers, `0` = note names | `numbers=0` |
+
+## Behavior
+
+- **All parameters are optional and independent.** Any subset may be present; missing parameters fall back to the visiting user's existing/default settings (FR-009).
+- **Invalid values are ignored, not errors.** An unrecognized `root`, `scale`, or `mode`, or a `color`/`flats`/`numbers` value other than `1`/`0`, causes that single parameter to be ignored; the rest of the page (and the rest of the URL's parameters) is unaffected (FR-008, SC-005).
+- **The current page always keeps the URL in sync.** Whenever a user changes the underlying scale, root, color mode, flat display, or number display through the existing UI, the browser's address bar is updated in place (no reload, no new history entry) so it always reflects the currently visible configuration (FR-006).
+- **Not instrument-scoped.** The same five parameters apply identically regardless of which instrument route they appear on (FR-011).
+
+## Example URLs
+
+- Full link: `/guitar?root=D&scale=major&color=1&flats=0&numbers=1`
+- Modal scale link: `/piano?root=E&scale=dorian&mode=dorian&color=0`
+- Partial link (only overrides root and flats, everything else stays at the recipient's own defaults): `/kalimba?root=Bb&flats=1`
+- Link with an invalid value (bad `scale` id is ignored, `root` still applies): `/flute?root=F&scale=not-a-real-scale`

--- a/specs/002-url-params/data-model.md
+++ b/specs/002-url-params/data-model.md
@@ -1,0 +1,29 @@
+# Phase 1 Data Model: Shareable URL Parameters for Scale Display Settings
+
+This feature has no persisted/database entities. The only "entity" is the shareable configuration already represented in the app's existing `GlobalConfig` Redux state (`src/features/globalConfig/globalConfigSlice.ts`), plus its query-string representation.
+
+## Entity: Scale Display Configuration
+
+The subset of `GlobalConfig` covered by this feature, and its URL query-string mapping.
+
+| Field (existing, in `GlobalConfig`) | Type | Query key | Validation rule |
+|---|---|---|---|
+| `scale.root` | `Note` (`src/lib/utils/note.ts`) | `root` | Must be one of the 12 sharp-spelled `ROOTS` values (`src/lib/utils/scaleConstants.ts`) — the app's root-note picker never uses flat spellings as `scale.root`'s canonical value, so those are rejected even though they're valid `Note` literals; otherwise ignored (fall back to current/default root). |
+| `scale.type` | `ScaleType` (`src/lib/utils/scaleType.ts`) — built-in id or custom scale id | `scale` | Must be one of `SCALE_TYPES` (`src/lib/utils/scaleConstants.ts`) or a custom scale id returned by `getCustomScales()` (`src/lib/utils/customScaleTypes.ts`); otherwise ignored. |
+| `scale.mode` | `ScaleMode \| undefined` | `mode` | Must be a member of the `ScaleMode` union when the resolved `scale` type supports modes; otherwise ignored/omitted. |
+| `highlightRoots` | `boolean` | `color` | Must be `"1"` or `"0"`; otherwise ignored. `1` → `true` (highlighted roots), `0` → `false` (monochrome). |
+| `showFlats` | `boolean` | `flats` | Must be `"1"` or `"0"`; otherwise ignored. `1` → `true` (flats), `0` → `false` (sharps). |
+| `showDegrees` | `boolean` | `numbers` | Must be `"1"` or `"0"`; otherwise ignored. `1` → `true` (scale degrees), `0` → `false` (note names). |
+
+### Relationships
+
+- This configuration is not tied to a specific instrument; it is read/written identically regardless of which instrument route (`/piano`, `/guitar`, `/kalimba`, `/harmonica`, `/flute`, `/recorder`) is active (FR-011).
+- It composes three of the existing `GlobalConfig` fields (`scale.root`, `scale.type`, `scale.mode`) and three independent boolean fields (`highlightRoots`, `showFlats`, `showDegrees`). No new Redux fields are introduced — this feature only adds a URL-facing read/write layer on top of the existing slice.
+
+### State transitions
+
+1. **Load with URL params present**: valid params overwrite the corresponding field(s) in `GlobalConfig` (taking precedence over the value restored from `localStorage`). Invalid/absent params leave the corresponding field at its current/default value.
+2. **User changes a setting via existing UI controls**: the existing Redux action fires as today (e.g. `setScale`, `toggleShowFlats`); the URL sync layer observes the resulting `GlobalConfig` change and mirrors the new value into the query string.
+3. **Navigation between instrument pages**: the five query params persist unchanged across the navigation (they are not instrument-scoped).
+
+No new persisted storage is introduced; `localStorage` persistence (via the existing `persistentStateMiddleware`) continues unchanged as the fallback for when the URL doesn't specify a setting.

--- a/specs/002-url-params/plan.md
+++ b/specs/002-url-params/plan.md
@@ -1,0 +1,90 @@
+# Implementation Plan: Shareable URL Parameters for Scale Display Settings
+
+**Branch**: `002-url-params` | **Date**: 2026-07-06 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/002-url-params/spec.md`
+
+**Note**: This template is filled in by the `/speckit-plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Reflect the app's shared scale display configuration — selected scale (type/mode), root note, color mode, flat display mode, and number display mode — as query-string parameters on the current instrument page's URL, kept in sync in both directions: URL params are applied to state on load (taking precedence over locally saved defaults), and any change to those settings via the existing UI is mirrored back into the URL immediately. This is implemented as a small Next.js App Router hook, wired into the existing `ClientLayout.tsx`, that reads/writes `useSearchParams()`/`router.replace()` against the existing `globalConfigSlice` Redux state — no new UI, no new persisted storage, no backend involved.
+
+## Technical Context
+
+**Language/Version**: TypeScript (strict mode), Next.js 16 (App Router), React 19
+
+**Primary Dependencies**: `@reduxjs/toolkit` / `react-redux` (existing `globalConfigSlice`), `next/navigation` (`useSearchParams`, `useRouter`, `usePathname`)
+
+**Storage**: Browser `localStorage` only (existing `persistentStateMiddleware`); no backend/database. N/A beyond what already exists.
+
+**Testing**: Jest + React Testing Library (existing `src/__tests__/` conventions)
+
+**Target Platform**: Web browsers (desktop + mobile), including the Capacitor-packaged Android build
+
+**Project Type**: Single Next.js web application (frontend only) — existing structure, no new project
+
+**Performance Goals**: URL reflects a settings change within 1s with no perceptible added latency to existing note-rendering/interaction performance (SC-002)
+
+**Constraints**: URL updates must not cause a full navigation/page reload or reset in-memory Redux state; must not add a new browser-history entry per change (would break back/forward usability per spec edge cases) — achieved via `router.replace(..., { scroll: false })` rather than `router.push`
+
+**Scale/Scope**: 5 shared settings (scale type, mode, root, color mode, flat display, number display — 6 URL keys total counting `mode` separately), synced uniformly across the 6 existing instrument routes (`/piano`, `/guitar`, `/kalimba`, `/harmonica`, `/flute`, `/recorder`)
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **State Management Guidelines — "URL state for navigation - Use Next.js App Router patterns"**: PASS. This feature is a direct implementation of that existing constitutional rule; no new state-management approach is introduced.
+- **TypeScript-First Development**: PASS. New encode/decode/validation helpers and the sync hook will be fully typed against existing `Note`, `ScaleType`, `ScaleMode`, and `GlobalConfig` types; no `any`.
+- **Performance-Driven Architecture**: PASS. Sync effect is scoped to the 5 relevant selectors only, using `router.replace` (no reload) so it does not add render or navigation overhead beyond a query-string update.
+- **Component Architecture (Single responsibility / custom hooks for complex logic)**: PASS. Logic is isolated in one new hook (`useUrlSyncedGlobalConfig`) rather than duplicated per instrument page.
+- **Accessibility / Progressive Enhancement / Musical Accuracy**: N/A — no UI, visual, or scale-calculation changes; existing components and calculations are reused as-is.
+- No violations identified. Complexity Tracking section is not needed.
+
+*Post-Phase 1 re-check*: Design artifacts (data-model.md, contracts/url-query-params.md, quickstart.md) introduce no new state-management pattern, no new project/module, and no persisted data beyond the existing Redux slice + localStorage. Constitution Check still PASSes with no violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/002-url-params/
+├── plan.md              # This file (/speckit-plan command output)
+├── research.md          # Phase 0 output (/speckit-plan command)
+├── data-model.md         # Phase 1 output (/speckit-plan command)
+├── quickstart.md        # Phase 1 output (/speckit-plan command)
+├── contracts/           # Phase 1 output (/speckit-plan command)
+│   └── url-query-params.md
+└── tasks.md             # Phase 2 output (/speckit-tasks command - NOT created by /speckit-plan)
+```
+
+### Source Code (repository root)
+
+```text
+# Option 1: Single project (existing Next.js app — no new top-level projects added)
+src/
+├── app/
+│   └── ClientLayout.tsx              # MODIFIED: invoke the new URL-sync hook
+├── features/
+│   └── globalConfig/
+│       ├── globalConfigSlice.ts      # UNCHANGED: existing selectors/actions reused
+│       ├── urlConfigParams.ts        # NEW: encode/decode/validate GlobalConfig <-> URLSearchParams
+│       └── useUrlSyncedGlobalConfig.ts  # NEW: hook wiring useSearchParams/router to the slice
+└── lib/
+    └── utils/
+        ├── scaleConstants.ts         # UNCHANGED: source of truth for valid scale/mode values
+        └── customScaleTypes.ts       # UNCHANGED: source of truth for valid custom scale ids
+
+src/__tests__/
+└── unit/
+    └── features/
+        └── globalConfig/
+            ├── urlConfigParams.test.ts        # NEW
+            └── useUrlSyncedGlobalConfig.test.ts  # NEW
+```
+
+**Structure Decision**: Existing single Next.js application structure is unchanged. This feature adds two new files colocated with the state they synchronize (`src/features/globalConfig/`) and one small change to the existing app-wide layout (`ClientLayout.tsx`), following the project's established "feature-organized" convention rather than introducing a new module or directory.
+
+## Complexity Tracking
+
+*No constitution violations identified — this section is not applicable.*

--- a/specs/002-url-params/quickstart.md
+++ b/specs/002-url-params/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: Validating Shareable URL Parameters
+
+Prerequisites: repo dependencies installed (`npm install`).
+
+## 1. Start the app
+
+```bash
+npm run dev
+```
+
+Open http://localhost:3000 in a browser; it should redirect to an instrument page (e.g. `/piano`).
+
+## 2. Verify the URL updates as you change settings (FR-006, SC-002)
+
+1. On any instrument page, change the scale, root, color mode toggle, flat/sharp toggle, and number-display toggle one at a time using the existing UI controls.
+2. After each change, check the browser's address bar — it should update immediately to include the corresponding query parameter from the [contract](contracts/url-query-params.md), without a page reload and without adding a new back-button history entry (test with the browser back button — it should not step through every toggle).
+
+## 3. Verify a full link reproduces the exact configuration (FR-007, SC-001, SC-003)
+
+1. Configure a distinctive combination (e.g. non-default scale/root, monochrome, flats on, numbers on) and copy the resulting URL.
+2. Open that URL in a new private/incognito window (so no `localStorage` state carries over).
+3. Confirm the page loads with the exact same scale, root, color mode, flat display, and number display as the source tab — see example URLs in the [contract](contracts/url-query-params.md#example-urls).
+
+## 4. Verify partial links fall back correctly (FR-009)
+
+1. Manually edit the URL to include only `root` and `flats` (remove `scale`, `mode`, `color`, `numbers`).
+2. Reload the page. Confirm root and flat display match the URL, while scale, color mode, and number display fall back to the current/default values.
+
+## 5. Verify invalid values are ignored gracefully (FR-008, SC-005)
+
+1. Manually edit the URL to set `scale=not-a-real-scale` while leaving `root=F` valid.
+2. Reload the page. Confirm the page loads without errors, `root` is applied as `F`, and `scale` falls back to the default/current value.
+
+## 6. Verify behavior is consistent across instruments (FR-011)
+
+1. With a distinctive configuration active and reflected in the URL, switch to a different instrument page.
+2. Confirm the five settings remain the same and the URL continues to reflect them on the new route.

--- a/specs/002-url-params/research.md
+++ b/specs/002-url-params/research.md
@@ -1,0 +1,58 @@
+# Phase 0 Research: Shareable URL Parameters for Scale Display Settings
+
+All items below were resolved by reading the existing codebase (Next.js 16 App Router app, Redux Toolkit `globalConfigSlice`, `ClientLayout.tsx`); no `NEEDS CLARIFICATION` markers remain from the spec, so no external research was required.
+
+## 1. Mechanism for reading/writing the query string
+
+- **Decision**: Use Next.js App Router's `useSearchParams()` to read the current query string and `useRouter().replace(url, { scroll: false })` to write it back.
+- **Rationale**: The project constitution explicitly calls for "URL state for navigation - Use Next.js App Router patterns." `router.replace` updates the address bar and query string without adding a new browser-history entry and without a full navigation/reload, satisfying FR-006 (immediate, automatic URL updates) while keeping back/forward behavior sane (see spec edge case on back/forward navigation). `ClientLayout.tsx` already uses `useRouter`/`usePathname` for instrument routing, so this keeps the pattern consistent.
+- **Alternatives considered**:
+  - `window.history.replaceState` directly — bypasses Next.js's router/URL synchronization, more brittle across App Router versions.
+  - `router.push` for every settings change — would add one history entry per toggle, making the back button unusable (explicitly called out as an edge case to avoid).
+
+## 2. Query parameter naming and encoding
+
+- **Decision**: Five short, human-readable query keys, mapped 1:1 to existing state:
+  | Query key | Redux field | Values |
+  |---|---|---|
+  | `root` | `scale.root` | Note names, e.g. `A`, `C#`, `Bb` |
+  | `scale` | `scale.type` | Built-in scale type id (e.g. `major`) or custom scale id (e.g. `custom-abc123`) |
+  | `mode` | `scale.mode` | Mode id (e.g. `ionian`), omitted when the scale type has no mode |
+  | `color` | `highlightRoots` | `1` (highlighted roots) / `0` (monochrome) |
+  | `flats` | `showFlats` | `1` (flats) / `0` (sharps) |
+  | `numbers` | `showDegrees` | `1` (scale degrees) / `0` (note names) |
+- **Rationale**: Keys read plainly in a shared link (part of "ease of sharing"), and map directly onto fields already defined in `src/lib/utils/scaleType.ts` (`Scale.root`, `Scale.type`, `Scale.mode`) and `globalConfigSlice.ts` (`highlightRoots`, `showFlats`, `showDegrees`), so no new vocabulary is introduced.
+- **Alternatives considered**: A single opaque encoded blob (e.g. base64 JSON in one `c=` param) — rejected because it isn't human-readable or hand-editable, which works against the sharing goal.
+
+## 3. Boolean encoding
+
+- **Decision**: `1`/`0` for the three boolean settings.
+- **Rationale**: Shortest, unambiguous representation; avoids bikeshedding between `true/false` and `on/off`.
+- **Alternatives considered**: `true`/`false` strings — functionally equivalent but longer with no added clarity.
+
+## 4. Validation of incoming values
+
+- **Decision**: Before dispatching any URL-sourced value into Redux, validate it against the current set of known values:
+  - `scale` against built-in `SCALE_TYPES` (`src/lib/utils/scaleConstants.ts`) plus custom scale ids from `getCustomScales()` (`src/lib/utils/customScaleTypes.ts`).
+  - `mode` against the `ScaleMode` union.
+  - `root` against the `Note` union (`src/lib/utils/note.ts`).
+  - `color`, `flats`, `numbers` against `"1"`/`"0"`.
+  Any value that fails validation is dropped (that setting falls back to its existing/default value); the rest of the URL's parameters are still applied.
+- **Rationale**: Directly satisfies FR-008/FR-009 and SC-005 (invalid or partial links must not break the page or affect unrelated settings). Reuses validation data that already exists in the app rather than adding a schema-validation dependency.
+- **Alternatives considered**: Rejecting the whole URL (or redirecting) on any invalid value — rejected, contradicts FR-008's requirement that other settings remain unaffected.
+
+## 5. Sync direction and precedence
+
+- **Decision**: Bidirectional, URL-wins-on-load:
+  1. On initial load/navigation, any of the five params present in the URL are applied to Redux, taking precedence over the locally persisted (localStorage) values for just those settings (FR-007, FR-009).
+  2. After load, any user-driven change to the five Redux settings is mirrored back into the URL (FR-006).
+- **Rationale**: This precedence is what makes User Stories 1–3 work: opening a shared/bookmarked link reproduces the sender's exact view (P1/P2), and partial links only override the settings they specify while leaving the rest at the recipient's own defaults (P3).
+- **Alternatives considered**: Write-only sync (URL reflects state but is never read back) — rejected, breaks the core sharing round-trip. Read-only sync (URL only applied once, not kept in sync) — rejected, fails FR-006/SC-002 (address bar must stay current for copy-at-any-time sharing).
+
+## 6. Where the sync logic lives
+
+- **Decision**: A single hook (e.g. `useUrlSyncedGlobalConfig`), invoked once from `ClientLayout.tsx`.
+- **Rationale**: The five settings already live in one shared slice (`globalConfigSlice`) used by every instrument page; `ClientLayout.tsx` is already the one place that reconciles the current route with Redux state (see its existing pathname → `setInstrument` effect), so this keeps the new logic in the same place rather than duplicating it across six instrument pages (FR-011).
+- **Alternatives considered**: Adding URL-sync effects independently inside each instrument page — rejected as duplicated logic for state that isn't instrument-specific.
+
+**Output**: All unknowns resolved; no `NEEDS CLARIFICATION` markers remain.

--- a/specs/002-url-params/spec.md
+++ b/specs/002-url-params/spec.md
@@ -1,0 +1,100 @@
+# Feature Specification: Shareable URL Parameters for Scale Display Settings
+
+**Feature Branch**: `002-url-params`
+
+**Created**: 2026-07-06
+
+**Status**: Draft
+
+**Input**: User description: "Add route parameters so that the selected scale, and root, color mode, flat display mode, and number display are set on the url as querystring params. for ease osharing."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Share the current view with a link (Priority: P1)
+
+A user has configured the app to show a specific scale, root note, color mode, flat/sharp display, and number display. They want to send this exact view to another person (e.g., a student or bandmate) so that person sees the identical setup without having to manually recreate each setting.
+
+**Why this priority**: This is the core value of the feature — enabling easy sharing is the stated goal. Without this, the feature delivers no value.
+
+**Independent Test**: Configure a non-default scale, root, color mode, flat display, and number display; copy the current browser URL; open it in a new browser session (or send to another device); confirm the same five settings are applied automatically.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has selected a scale, root note, color mode, flat display mode, and number display, **When** they copy the current page URL, **Then** the URL contains query parameters that fully describe those five settings.
+2. **Given** a URL containing valid query parameters for all five settings, **When** a different user (or the same user in a new session) opens that URL, **Then** the page loads with those exact five settings applied, without any additional clicks.
+3. **Given** a user changes any one of the five settings while on the page, **When** the change is applied, **Then** the browser URL updates automatically to reflect the new value, so the address bar can be copied at any time.
+
+---
+
+### User Story 2 - Bookmark a favorite configuration (Priority: P2)
+
+A user wants to save a bookmark to a particular scale/root/display combination they use often, so they can return to it later without reconfiguring.
+
+**Why this priority**: Builds on the same URL-encoding mechanism as sharing, but serves a personal-recall use case rather than sharing with others.
+
+**Independent Test**: Configure the five settings, bookmark the page (or save the URL), close the browser, reopen the saved URL later, and confirm the same configuration is restored.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user has bookmarked a URL containing the five query parameters, **When** they open the bookmark at a later time, **Then** the page restores the exact configuration captured at bookmark time, regardless of what the user's default/last-used settings currently are.
+
+---
+
+### User Story 3 - Open a link with only some parameters set (Priority: P3)
+
+A user receives or constructs a URL that only specifies some of the five settings (e.g., only scale and root), with the rest omitted.
+
+**Why this priority**: Improves robustness and supports simpler, hand-authored share links (e.g., "just show my scale, keep your own display preferences"), but is a secondary refinement of the core sharing behavior.
+
+**Independent Test**: Open a URL with only a subset of the five query parameters present; confirm the specified settings are applied and the remaining settings fall back to the user's existing/default preferences without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a URL with only some of the five query parameters present, **When** the page loads, **Then** the specified settings are applied and the unspecified settings use the current default/last-used values.
+
+---
+
+### Edge Cases
+
+- What happens when a query parameter value is invalid or unrecognized (e.g., a misspelled scale name, an unsupported root note)? The affected setting MUST fall back to its default value rather than breaking the page or crashing the app.
+- What happens when a URL contains no query parameters at all? The page MUST behave as it does today (using saved/default settings).
+- What happens when a user navigates using the browser's back/forward buttons after changing settings? The displayed configuration MUST match the settings encoded in the URL for that history entry.
+- What happens when a user switches between instrument pages (e.g., piano to guitar)? The five shared settings encoded in the URL MUST continue to apply consistently since they are shared across instruments.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST reflect the currently selected scale (including its mode/type) in the page's URL as a query parameter.
+- **FR-002**: System MUST reflect the currently selected root note in the page's URL as a query parameter.
+- **FR-003**: System MUST reflect the current color mode (highlighted root notes vs. monochrome) in the page's URL as a query parameter.
+- **FR-004**: System MUST reflect the current flat/sharp note-naming display mode in the page's URL as a query parameter.
+- **FR-005**: System MUST reflect the current number/scale-degree display mode in the page's URL as a query parameter.
+- **FR-006**: System MUST update the URL automatically and immediately whenever the user changes any of the five settings, without requiring a page reload or manual action.
+- **FR-007**: When a page is loaded with a URL containing any of these five query parameters, the system MUST initialize the corresponding settings from the URL rather than from saved/default preferences.
+- **FR-008**: System MUST ignore invalid or unrecognized values for any of the five query parameters and fall back to that setting's default value, without affecting the other settings or breaking the page.
+- **FR-009**: System MUST support partial parameter sets — any of the five parameters that are absent from the URL MUST fall back to the user's existing/default preference for that setting.
+- **FR-010**: Copying the URL from the address bar at any point in time MUST reproduce the exact visual configuration (scale, root, color mode, flat display, number display) for anyone who opens it.
+- **FR-011**: The five settings and their URL representation MUST remain consistent as a user navigates between different instrument pages within the app.
+
+### Key Entities
+
+- **Scale Display Configuration**: The shareable combination of settings covered by this feature — selected scale (type/mode), root note, color mode, flat display mode, and number display mode. This configuration is not tied to a specific instrument and is shared across all instrument pages.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A user can share their exact scale display configuration with another person by copying and pasting the browser URL, and the recipient sees an identical setup (scale, root, color mode, flat display, number display) 100% of the time for valid links.
+- **SC-002**: The shareable URL updates to reflect a changed setting within 1 second of the user making that change, with no manual action required.
+- **SC-003**: Opening a link containing all five settings fully restores the intended configuration immediately on page load, with no extra clicks needed.
+- **SC-004**: A user can bookmark a specific configuration and, when returning to it at any later time, see the exact same configuration restored, independent of their current default preferences.
+- **SC-005**: Links containing invalid or malformed values for any of the five settings still load the page successfully, using default values for the invalid settings only.
+
+## Assumptions
+
+- The five settings apply across all instrument pages that use the shared scale/display configuration (piano, guitar, kalimba, harmonica, flute, recorder), since these settings are currently shared app-wide rather than per-instrument.
+- Instrument selection itself and instrument-specific settings (e.g., guitar tuning, fret count, custom scales/chords) are out of scope for this feature; only the five explicitly requested settings (scale, root, color mode, flat display mode, number display) are addressed.
+- Existing local-storage-based persistence of user preferences remains as the fallback used whenever the URL does not specify a given setting.
+- No authentication or access control is required, since this feature only affects a client-side visual/display configuration and does not expose or transmit private data.
+- "Color mode" refers to the existing highlighted-root-notes vs. monochrome display toggle; "number display" refers to the existing scale-degree-number display toggle.

--- a/specs/002-url-params/tasks.md
+++ b/specs/002-url-params/tasks.md
@@ -1,0 +1,179 @@
+---
+
+description: "Task list for feature implementation"
+---
+
+# Tasks: Shareable URL Parameters for Scale Display Settings
+
+**Input**: Design documents from `/specs/002-url-params/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/url-query-params.md](./contracts/url-query-params.md), [quickstart.md](./quickstart.md)
+
+**Tests**: Included. The project constitution mandates a minimum 80% test coverage standard, and the existing `globalConfig` slice already has test coverage — new logic follows the same convention.
+
+**Organization**: Tasks are grouped by user story (from spec.md) to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+## Path Conventions
+
+Single Next.js project (existing structure) — all paths are relative to the repository root, under `src/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm a clean starting point; no new dependencies are required for this feature (reuses existing `next/navigation` and `@reduxjs/toolkit`).
+
+- [X] T001 Run `npm run lint` and `npm test` on branch `002-url-params` to confirm a clean baseline before making changes; note (do not fix) any pre-existing unrelated failures. **Result**: `npm test` passes clean (19 suites, 195 tests). `npm run lint` / `next lint` and direct `eslint .` both fail with pre-existing, unrelated errors (Next 16's `next lint` no longer resolves as expected here, and the flat ESLint config crashes with a circular-JSON error in `@eslint/eslintrc`) — not introduced by this feature, not fixed here.
+
+**Checkpoint**: Baseline confirmed clean (or pre-existing issues documented as out of scope).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The encode/decode/validation module and the slice setters that every user story (US1, US2, US3) depends on identically — they all read/write the same five settings through the same mechanism.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Add idempotent setter reducers `setShowFlats`, `setHighlightRoots`, `setShowDegrees` (each `PayloadAction<boolean>`) to `src/features/globalConfig/globalConfigSlice.ts`, alongside the existing `toggleShowFlats`/`toggleShowMonochrome`/`toggleShowDegrees` reducers (keep the toggles — existing UI controls use them). Export the new actions. These are needed because URL-driven sync must set an exact value, and the existing reducers only toggle.
+- [X] T003 [P] Create `src/features/globalConfig/urlConfigParams.ts` with the query-key mapping types/constants from [contracts/url-query-params.md](./contracts/url-query-params.md): `root`, `scale`, `mode`, `color`, `flats`, `numbers`.
+- [X] T004 Implement `encodeGlobalConfigToParams(config: { scale: Scale; highlightRoots: boolean; showFlats: boolean; showDegrees: boolean }): URLSearchParams` in `src/features/globalConfig/urlConfigParams.ts`, writing all six query keys per [data-model.md](./data-model.md) (booleans as `"1"`/`"0"`; `mode` omitted when `scale.mode` is undefined). (depends on T003)
+- [X] T005 Implement `decodeParamsToGlobalConfigPatch(params: URLSearchParams): { root?: Note; scaleType?: ScaleType; mode?: ScaleMode; highlightRoots?: boolean; showFlats?: boolean; showDegrees?: boolean }` in `src/features/globalConfig/urlConfigParams.ts`. Validate each key independently per [data-model.md](./data-model.md) — `root` against the `Note` union, `scale` against `SCALE_TYPES` (`src/lib/utils/scaleConstants.ts`) plus `getCustomScales()` (`src/lib/utils/customScaleTypes.ts`), `mode` against `ScaleMode`, and the three booleans against `"1"`/`"0"`. Omit any key from the returned patch that is absent or fails validation — never throw. (depends on T003)
+- [X] T006 [P] Unit tests for `encodeGlobalConfigToParams` and `decodeParamsToGlobalConfigPatch` in `src/__tests__/unit/features/globalConfig/urlConfigParams.test.ts`: full valid round-trip; each of `root`/`scale`/`mode`/`color`/`flats`/`numbers` individually invalid is omitted from the patch while the rest still decode; a custom scale id from `getCustomScales()` is accepted; an empty `URLSearchParams` yields an empty patch. **Also covers T015 (mixed valid/invalid params in one query string)** — see the last two tests in the file. (depends on T004, T005) — 11/11 passing, 97.95% line coverage on `urlConfigParams.ts`.
+
+**Checkpoint**: Encode/decode/validation module and slice setters are complete and unit-tested — all user stories build on this.
+
+---
+
+## Phase 3: User Story 1 - Share the current view with a link (Priority: P1) 🎯 MVP
+
+**Goal**: The browser URL always reflects the current scale, root, color mode, flat display, and number display; opening a URL with these params applies them immediately.
+
+**Independent Test**: Per [quickstart.md](./quickstart.md) steps 1–3 — change each of the five settings and watch the address bar update live; copy the resulting URL into a new private/incognito window and confirm it reproduces the exact configuration.
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Implement `useUrlSyncedGlobalConfig()` in `src/features/globalConfig/useUrlSyncedGlobalConfig.ts`: on mount and whenever `useSearchParams()` changes, call `decodeParamsToGlobalConfigPatch`, then dispatch `setScale` (merging `root`/`scaleType`/`mode` overrides onto the current `scale`), `setShowFlats`, `setHighlightRoots`, and/or `setShowDegrees` — but only for keys present in the returned patch. **Implementation note**: reads "current" store values via a `useRef` kept fresh every render (`currentConfigRef`), rather than depending on the selectors directly, so this effect only re-runs when the URL itself changes (`[searchParams, dispatch]`) and never fights a live user-driven edit by re-applying a stale URL value. (depends on T002, T005)
+- [X] T008 [US1] In `useUrlSyncedGlobalConfig()`, add an effect that watches `scale`, `highlightRoots`, `showFlats`, `showDegrees` (plus `pathname`/`router`/`searchParams`) and calls `router.replace(`${pathname}?${encodeGlobalConfigToParams({ scale, highlightRoots, showFlats, showDegrees }).toString()}`, { scroll: false })` whenever the encoded query differs from the current `searchParams`. **Implementation note**: this effect deliberately skips its very first invocation (via an `isFirstWriteRef` guard) — on mount, the URL→store effect above may dispatch changes that haven't propagated to this effect's closure within the same commit; skipping the first write avoids clobbering a shared link's values with stale pre-dispatch defaults, and the resulting re-render (if any) supplies settled values before anything is written. (depends on T004, T007)
+- [X] T009 [US1] Invoke `useUrlSyncedGlobalConfig()` once from `src/app/ClientLayout.tsx`, placed textually *after* the existing localStorage `current-scale` restore effect (so URL-driven dispatches run after and override it within the same effect pass, per FR-007 — see T012). **Also required an unplanned change**: `useSearchParams()` requires a Suspense boundary for Next.js static prerendering (`next build` failed with "useSearchParams() should be wrapped in a suspense boundary" until fixed) — added `<Suspense fallback={null}>` around `<ClientLayout>` in `src/app/layout.tsx`. Verified with `npm run build` (succeeds, all 7 routes prerender). (depends on T007, T008)
+- [X] T010 [P] [US1] Tests for `useUrlSyncedGlobalConfig` in `src/__tests__/unit/features/globalConfig/useUrlSyncedGlobalConfig.test.tsx` (`.tsx`, not `.ts` — needs JSX for the `<Provider>` wrapper): params present in the URL on initial render are dispatched into the store; a store change (e.g. `setScale`) results in a `router.replace` call (not `router.push`) with the expected query string. Mocks `next/navigation`. (depends on T007, T008) — 5/5 passing, 97%+ coverage.
+- [X] T011 [US1] Manually validated [quickstart.md](./quickstart.md) steps 1–3 with Playwright against the dev server: full-link round trip in a fresh browser context correctly set the root/scale `<select>` values; changing a setting via the UI live-updated the address bar; no console errors, no update-loop/act() warnings under rapid changes. **Bug found and fixed during this validation**: `decodeParamsToGlobalConfigPatch`'s `root` validation originally accepted the full `Note` union (including flat spellings like `Bb`), but the app's actual root-note `<select>` (`src/components/Header.tsx`) only ever offers the 12 sharp-spelled `ROOTS` values as `scale.root` — accepting `Bb` set state the UI couldn't render, silently resetting the dropdown. Fixed `urlConfigParams.ts` to validate `root` against `ROOTS` instead of the full `Note` type; updated `data-model.md`/`contracts/url-query-params.md` and the affected unit tests accordingly.
+
+**Checkpoint**: User Story 1 is fully functional and independently testable — this is the shippable MVP. ✅ Verified via `npm test` (212/212 passing) and `npm run build` (all routes prerender successfully).
+
+---
+
+## Phase 4: User Story 2 - Bookmark a favorite configuration (Priority: P2)
+
+**Goal**: A URL captured at one point in time reliably reproduces that exact configuration later, even if the user's current default/local settings have since changed.
+
+**Independent Test**: Per [quickstart.md](./quickstart.md) — save a configured URL, change settings afterward (so `localStorage` now holds different values), then reopen the saved URL and confirm the original configuration is restored, not the changed one.
+
+### Implementation for User Story 2
+
+- [X] T012 [P] [US2] Added a test ("US2: URL-provided values take precedence...") in `src/__tests__/unit/features/globalConfig/useUrlSyncedGlobalConfig.test.tsx` asserting that URL-provided values take precedence over pre-existing store values on load (dispatches a differing `setScale` before rendering the hook, then asserts the URL's values win per FR-007). Passing. (depends on T007)
+- [X] T013 [US2] Not needed: T012's test passed against the ordering already established in T009 (hook invoked after the localStorage-restore effect in `ClientLayout.tsx`), and this was independently confirmed live — a Playwright session that carried over `localStorage` state across navigations (`/piano` → `/kalimba`) showed URL-specified values correctly overriding it. No code change required. (depends on T009, T012)
+- [X] T014 [US2] Manually validated bookmarking-equivalent behavior with Playwright: navigated to a fully-specified URL, then navigated (via `page.goto`, a full reload — equivalent to reopening a bookmark) to a different URL in the same browser context; the second URL's values were correctly applied on top of the first navigation's persisted `localStorage` state, with no stale values leaking through.
+
+**Checkpoint**: User Stories 1 and 2 both work independently — bookmarked links survive changes to current defaults. ✅ Verified.
+
+---
+
+## Phase 5: User Story 3 - Open a link with only some parameters set (Priority: P3)
+
+**Goal**: Partial or partially-invalid query strings apply only their recognized, valid settings and leave the rest at the current/default values, without errors.
+
+**Independent Test**: Per [quickstart.md](./quickstart.md) steps 4–5 — open a URL with only some of the five settings present, and separately a URL containing one invalid value alongside valid ones; confirm only the valid/present settings are applied and nothing breaks.
+
+### Implementation for User Story 3
+
+- [X] T015 [P] [US3] Added tests in `src/__tests__/unit/features/globalConfig/urlConfigParams.test.ts` for a single query string mixing valid and invalid params (valid `root` alongside an invalid `scale`; also a dedicated test for a flat-spelled `root` being rejected — see the T011 bug note), asserting only the valid keys appear in the decoded patch. Passing. (depends on T005)
+- [X] T016 [US3] Added tests ("US3: ...") in `src/__tests__/unit/features/globalConfig/useUrlSyncedGlobalConfig.test.tsx` confirming that loading with a partial query string applies only the present/valid keys and leaves the rest at default, and that an invalid value is ignored without throwing or affecting other settings. Passing. (depends on T007)
+- [X] T017 [US3] Manually validated with Playwright across `/piano`, `/kalimba`, and `/guitar`: a partial link (`root` + `flats` only) applied just those two settings; an invalid-`scale` link applied the valid `root` while `scale` fell back to default; navigating between instrument routes with no new query params preserved all five settings unchanged (FR-011), confirmed on both a Redux-only page (piano/kalimba) and the Context-based guitar page.
+
+**Checkpoint**: All three user stories are independently functional and verified. ✅
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification across the whole feature.
+
+- [X] T018 [P] `npm run lint` still fails with the same pre-existing, unrelated error noted in T001 (Next 16 / `@eslint/eslintrc` circular-JSON crash) — not introduced by this feature. Manually confirmed the new/modified files (`globalConfigSlice.ts`, `urlConfigParams.ts`, `useUrlSyncedGlobalConfig.ts`, `ClientLayout.tsx`, `layout.tsx`) use strict TypeScript throughout with no `any`, and `npm run build`'s TypeScript pass succeeded cleanly.
+- [X] T019 [P] Full `npm test` suite: 21/21 suites, 212/212 tests passing, no regressions.
+- [X] T020 Manually validated quickstart.md step 6 (cross-instrument consistency) via Playwright — see T017.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately.
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories.
+- **User Stories (Phase 3–5)**: All depend on Foundational phase completion.
+  - US2 and US3 build directly on the hook created in US1 (T007/T008) — see notes below.
+- **Polish (Phase 6)**: Depends on all three user stories being complete.
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2). No dependency on other stories.
+- **User Story 2 (P2)**: Reuses the hook built in US1 (T007) — its tasks add coverage/ordering fixes for a specific precedence rule rather than new parallel infrastructure, so in practice it follows US1.
+- **User Story 3 (P3)**: Reuses the same hook and decode function built in US1/Foundational — its tasks add coverage for partial/invalid-value handling that Foundational (T005) already implements, so in practice it also follows US1.
+
+### Within Each User Story
+
+- Implementation before tests where the test targets that story's specific new behavior (US1); tests-first is used for US2/US3 since they primarily add regression coverage over Foundational/US1 code.
+- Story complete before moving to the next priority when working solo; independently testable at each checkpoint.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel (different files).
+- T006 can run once T004 and T005 are both done.
+- T010, T012, T015 are test-only tasks in different describe blocks / files and can be parallelized with each other once their respective dependencies (T007/T008, T005) are done.
+- T018 and T019 can run in parallel.
+
+---
+
+## Parallel Example: Foundational Phase
+
+```bash
+# Launch in parallel (different files):
+Task: "Add idempotent setter reducers to src/features/globalConfig/globalConfigSlice.ts"
+Task: "Create query-key mapping types/constants in src/features/globalConfig/urlConfigParams.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL — blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Run quickstart.md steps 1–3 independently
+5. Ship — this alone delivers the "shareable link" value the feature was requested for
+
+### Incremental Delivery
+
+1. Setup + Foundational → shared encode/decode/validate module and slice setters ready
+2. Add User Story 1 → validate → MVP shippable (sharing works end-to-end)
+3. Add User Story 2 → validate → bookmarking precedence confirmed
+4. Add User Story 3 → validate → partial/invalid-link robustness confirmed
+5. Polish → lint, full test suite, final cross-instrument check
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies on incomplete tasks
+- [Story] label maps task to specific user story for traceability
+- Commit after each task or logical group
+- Stop at any checkpoint to validate a story independently
+- US2 and US3 are lightweight on top of US1 by design: the underlying sync mechanism is shared and already implements URL-precedence (FR-007) and partial/invalid-value tolerance (FR-008/FR-009) in Foundational + US1; US2/US3 tasks exist primarily to add explicit test coverage and close any gaps found, not to build parallel new infrastructure.

--- a/src/__tests__/unit/features/globalConfig/urlConfigParams.test.ts
+++ b/src/__tests__/unit/features/globalConfig/urlConfigParams.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Spec: specs/002-url-params/spec.md — FR-001..FR-005, FR-008, FR-009
+ */
+
+import {
+  encodeGlobalConfigToParams,
+  decodeParamsToGlobalConfigPatch,
+  URL_PARAM_KEYS,
+} from "@/features/globalConfig/urlConfigParams";
+import { Scale } from "@/lib/utils/scaleType";
+
+describe("encodeGlobalConfigToParams", () => {
+  it("encodes all five settings into query params", () => {
+    const scale: Scale = { root: "D", type: "major" };
+    const params = encodeGlobalConfigToParams({
+      scale,
+      highlightRoots: true,
+      showFlats: false,
+      showDegrees: true,
+    });
+
+    expect(params.get(URL_PARAM_KEYS.root)).toBe("D");
+    expect(params.get(URL_PARAM_KEYS.scaleType)).toBe("major");
+    expect(params.get(URL_PARAM_KEYS.mode)).toBeNull();
+    expect(params.get(URL_PARAM_KEYS.highlightRoots)).toBe("1");
+    expect(params.get(URL_PARAM_KEYS.showFlats)).toBe("0");
+    expect(params.get(URL_PARAM_KEYS.showDegrees)).toBe("1");
+  });
+
+  it("includes mode when the scale has one", () => {
+    const scale: Scale = { root: "E", type: "dorian", mode: "dorian" };
+    const params = encodeGlobalConfigToParams({
+      scale,
+      highlightRoots: false,
+      showFlats: false,
+      showDegrees: false,
+    });
+
+    expect(params.get(URL_PARAM_KEYS.mode)).toBe("dorian");
+  });
+});
+
+describe("decodeParamsToGlobalConfigPatch", () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("round-trips a fully valid query string", () => {
+    const scale: Scale = { root: "C#", type: "harmonic-minor" };
+    const encoded = encodeGlobalConfigToParams({
+      scale,
+      highlightRoots: true,
+      showFlats: true,
+      showDegrees: false,
+    });
+
+    const patch = decodeParamsToGlobalConfigPatch(encoded);
+
+    expect(patch).toEqual({
+      root: "C#",
+      scaleType: "harmonic-minor",
+      highlightRoots: true,
+      showFlats: true,
+      showDegrees: false,
+    });
+  });
+
+  it("returns an empty patch for an empty query string", () => {
+    expect(decodeParamsToGlobalConfigPatch(new URLSearchParams())).toEqual({});
+  });
+
+  it("omits an invalid root but keeps other valid values", () => {
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.root]: "H#",
+      [URL_PARAM_KEYS.scaleType]: "major",
+    });
+
+    const patch = decodeParamsToGlobalConfigPatch(params);
+
+    expect(patch.root).toBeUndefined();
+    expect(patch.scaleType).toBe("major");
+  });
+
+  it("omits an invalid scale type but keeps other valid values", () => {
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.root]: "F",
+      [URL_PARAM_KEYS.scaleType]: "not-a-real-scale",
+    });
+
+    const patch = decodeParamsToGlobalConfigPatch(params);
+
+    expect(patch.root).toBe("F");
+    expect(patch.scaleType).toBeUndefined();
+  });
+
+  it("omits an invalid mode", () => {
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.mode]: "not-a-mode",
+    });
+
+    expect(decodeParamsToGlobalConfigPatch(params).mode).toBeUndefined();
+  });
+
+  it("omits boolean flags with values other than 1/0", () => {
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.highlightRoots]: "true",
+      [URL_PARAM_KEYS.showFlats]: "yes",
+      [URL_PARAM_KEYS.showDegrees]: "0",
+    });
+
+    const patch = decodeParamsToGlobalConfigPatch(params);
+
+    expect(patch.highlightRoots).toBeUndefined();
+    expect(patch.showFlats).toBeUndefined();
+    expect(patch.showDegrees).toBe(false);
+  });
+
+  it("accepts a custom scale id registered in localStorage", () => {
+    localStorage.setItem(
+      "custom-scales",
+      JSON.stringify([
+        {
+          id: "custom-abc123",
+          label: "My Scale",
+          group: "Custom",
+          intervals: [0, 2, 4, 5, 7, 9, 11],
+        },
+      ])
+    );
+
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.scaleType]: "custom-abc123",
+    });
+
+    expect(decodeParamsToGlobalConfigPatch(params).scaleType).toBe(
+      "custom-abc123"
+    );
+  });
+
+  it("supports a partial parameter set", () => {
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.root]: "A#",
+      [URL_PARAM_KEYS.showFlats]: "1",
+    });
+
+    expect(decodeParamsToGlobalConfigPatch(params)).toEqual({
+      root: "A#",
+      showFlats: true,
+    });
+  });
+
+  it("omits a flat-spelled root, since scale.root only ever uses sharp spellings", () => {
+    const params = new URLSearchParams({ [URL_PARAM_KEYS.root]: "Bb" });
+
+    expect(decodeParamsToGlobalConfigPatch(params).root).toBeUndefined();
+  });
+
+  it("omits multiple invalid values while keeping valid ones from the same query string", () => {
+    const params = new URLSearchParams({
+      [URL_PARAM_KEYS.root]: "D",
+      [URL_PARAM_KEYS.scaleType]: "bogus-scale",
+      [URL_PARAM_KEYS.highlightRoots]: "1",
+      [URL_PARAM_KEYS.showFlats]: "maybe",
+    });
+
+    expect(decodeParamsToGlobalConfigPatch(params)).toEqual({
+      root: "D",
+      highlightRoots: true,
+    });
+  });
+});

--- a/src/__tests__/unit/features/globalConfig/useUrlSyncedGlobalConfig.test.tsx
+++ b/src/__tests__/unit/features/globalConfig/useUrlSyncedGlobalConfig.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Spec: specs/002-url-params/spec.md — FR-006, FR-007, FR-008, FR-009
+ * Also covers T012 (US2 — URL precedence over localStorage-restored state)
+ * and T016 (US3 — partial/invalid query strings).
+ */
+
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { createTestStore } from "../../../test-utils";
+import { useUrlSyncedGlobalConfig } from "@/features/globalConfig/useUrlSyncedGlobalConfig";
+import { setScale } from "@/features/globalConfig/globalConfigSlice";
+
+jest.mock("next/navigation", () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+const mockedUseRouter = useRouter as jest.Mock;
+const mockedUsePathname = usePathname as jest.Mock;
+const mockedUseSearchParams = useSearchParams as jest.Mock;
+
+function renderHookWithStore(
+  store: ReturnType<typeof createTestStore>,
+  searchParams: URLSearchParams,
+  pathname = "/piano"
+) {
+  const replace = jest.fn();
+  const push = jest.fn();
+  mockedUseRouter.mockReturnValue({ replace, push });
+  mockedUsePathname.mockReturnValue(pathname);
+  mockedUseSearchParams.mockReturnValue(searchParams);
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  const view = renderHook(() => useUrlSyncedGlobalConfig(), { wrapper });
+  return { ...view, replace, push, store };
+}
+
+describe("useUrlSyncedGlobalConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("applies valid params found in the URL to the store on initial render", () => {
+    const store = createTestStore();
+    const params = new URLSearchParams({ root: "D", scale: "major", color: "0" });
+
+    renderHookWithStore(store, params);
+
+    const state = store.getState().globalConfig;
+    expect(state.scale.root).toBe("D");
+    expect(state.scale.type).toBe("major");
+    expect(state.highlightRoots).toBe(false);
+  });
+
+  it("mirrors a store change back into the URL via router.replace, not push", () => {
+    const store = createTestStore();
+    const { replace, push } = renderHookWithStore(store, new URLSearchParams());
+
+    act(() => {
+      store.dispatch(setScale({ root: "G", type: "minor" }));
+    });
+
+    expect(replace).toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+    const [url, options] = replace.mock.calls[replace.mock.calls.length - 1];
+    expect(url).toContain("root=G");
+    expect(url).toContain("scale=minor");
+    expect(options).toEqual({ scroll: false });
+  });
+
+  it("US2: URL-provided values take precedence over pre-existing (e.g. localStorage-restored) store values", () => {
+    const store = createTestStore();
+    // Simulate a prior localStorage restore that already set a different scale.
+    store.dispatch(setScale({ root: "F", type: "blues" }));
+
+    const params = new URLSearchParams({ root: "A", scale: "dorian", mode: "dorian" });
+    renderHookWithStore(store, params);
+
+    const state = store.getState().globalConfig;
+    expect(state.scale).toEqual({ root: "A", type: "dorian", mode: "dorian" });
+  });
+
+  it("US3: applies only the valid/present keys from a partial query string", () => {
+    const store = createTestStore();
+    const params = new URLSearchParams({ root: "A#", flats: "1" });
+
+    renderHookWithStore(store, params);
+
+    const state = store.getState().globalConfig;
+    expect(state.scale.root).toBe("A#");
+    expect(state.showFlats).toBe(true);
+    // Untouched settings keep their existing/default values.
+    expect(state.scale.type).toBe(store.getState().globalConfig.scale.type);
+    expect(state.highlightRoots).toBe(true); // default
+  });
+
+  it("US3: ignores an invalid value in a query string without throwing or affecting other settings", () => {
+    const store = createTestStore();
+    const params = new URLSearchParams({ root: "F", scale: "not-a-real-scale" });
+
+    expect(() => renderHookWithStore(store, params)).not.toThrow();
+
+    const state = store.getState().globalConfig;
+    expect(state.scale.root).toBe("F");
+    expect(state.scale.type).toBe("major"); // default, invalid value ignored
+  });
+});

--- a/src/app/ClientLayout.tsx
+++ b/src/app/ClientLayout.tsx
@@ -24,6 +24,7 @@ import {
 import { setAudioStatus } from "@/features/audio/audioSlice";
 import { initializeAudio } from "@/lib/utils/audioUtils";
 import { SCALE_TYPES, SCALE_PATTERNS } from "@/lib/utils/scaleConstants";
+import { useUrlSyncedGlobalConfig } from "@/features/globalConfig/useUrlSyncedGlobalConfig";
 
 interface ClientLayoutProps {
   children: React.ReactNode;
@@ -91,6 +92,11 @@ export default function ClientLayout({ children }: ClientLayoutProps) {
       }
     }
   }, [router, dispatch, isHydrated]);
+
+  // Keep the URL's query string and the shared scale display configuration
+  // in sync; must run after the localStorage restore above so that URL
+  // params take precedence (FR-007) within the same effect pass.
+  useUrlSyncedGlobalConfig();
 
   useEffect(() => {
     if (!isHydrated) return;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import ClientLayout from "./ClientLayout";
@@ -35,7 +36,9 @@ export default function RootLayout({
         suppressHydrationWarning
       >
         <Providers>
-          <ClientLayout>{children}</ClientLayout>
+          <Suspense fallback={null}>
+            <ClientLayout>{children}</ClientLayout>
+          </Suspense>
         </Providers>
       </body>
     </html>

--- a/src/features/globalConfig/globalConfigSlice.ts
+++ b/src/features/globalConfig/globalConfigSlice.ts
@@ -1,5 +1,5 @@
 import { TuningPreset } from "@/app/guitar/types/tuningPreset";
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { WritableDraft } from "@reduxjs/toolkit";
 import { initializeApplication } from "../application/applicationSlice";
 import { Instrument } from "@/lib/utils/instrument";
@@ -103,11 +103,20 @@ export const globalConfigSlice = createSlice({
     toggleShowFlats: (state) => {
       state.showFlats = !state.showFlats;
     },
+    setShowFlats: (state, action: PayloadAction<boolean>) => {
+      state.showFlats = action.payload;
+    },
     toggleShowMonochrome: (state) => {
       state.highlightRoots = !state.highlightRoots;
     },
+    setHighlightRoots: (state, action: PayloadAction<boolean>) => {
+      state.highlightRoots = action.payload;
+    },
     toggleShowDegrees: (state) => {
       state.showDegrees = !state.showDegrees;
+    },
+    setShowDegrees: (state, action: PayloadAction<boolean>) => {
+      state.showDegrees = action.payload;
     },
     toggleChordScaleMode: (state) => {
       state.chordScaleMode = !state.chordScaleMode;
@@ -137,8 +146,11 @@ export const {
   setScale,
   setCurrentTuning,
   toggleShowFlats,
+  setShowFlats,
   toggleShowMonochrome,
+  setHighlightRoots,
   toggleShowDegrees,
+  setShowDegrees,
   toggleChordScaleMode,
   setSelectedChord,
   setSoundEngine,

--- a/src/features/globalConfig/urlConfigParams.ts
+++ b/src/features/globalConfig/urlConfigParams.ts
@@ -1,0 +1,129 @@
+/**
+ * URL query-parameter mapping for the shareable Scale Display Configuration.
+ *
+ * Spec: specs/002-url-params/spec.md
+ * Contract: specs/002-url-params/contracts/url-query-params.md
+ * Data model: specs/002-url-params/data-model.md
+ */
+
+import { Note } from "@/lib/utils/note";
+import { Scale, ScaleMode, ScaleType } from "@/lib/utils/scaleType";
+import { ROOTS, SCALE_TYPES } from "@/lib/utils/scaleConstants";
+import { getCustomScales } from "@/lib/utils/customScaleTypes";
+
+export const URL_PARAM_KEYS = {
+  root: "root",
+  scaleType: "scale",
+  mode: "mode",
+  highlightRoots: "color",
+  showFlats: "flats",
+  showDegrees: "numbers",
+} as const;
+
+// The app's root-note picker (src/components/Header.tsx) only ever offers
+// the sharp-spelled ROOTS values as its canonical `scale.root`; flat
+// spellings ("Bb", "Db", ...) are display-only elsewhere in the app and are
+// not values `scale.root` itself takes, so they must not be accepted here.
+const VALID_NOTES: readonly Note[] = ROOTS;
+
+const VALID_SCALE_MODES: readonly ScaleMode[] = [
+  "ionian",
+  "dorian",
+  "phrygian",
+  "lydian",
+  "mixolydian",
+  "aeolian",
+  "locrian",
+];
+
+const isValidNote = (value: string): value is Note =>
+  (VALID_NOTES as readonly string[]).includes(value);
+
+const isValidScaleMode = (value: string): value is ScaleMode =>
+  (VALID_SCALE_MODES as readonly string[]).includes(value);
+
+const isValidScaleType = (value: string): value is ScaleType => {
+  const builtInIds: readonly string[] = SCALE_TYPES.map((s) => s.value);
+  const customIds = getCustomScales().map((s) => s.id);
+  return builtInIds.includes(value) || customIds.includes(value);
+};
+
+const isBooleanFlag = (value: string): value is "1" | "0" =>
+  value === "1" || value === "0";
+
+export interface GlobalConfigUrlSlice {
+  scale: Scale;
+  highlightRoots: boolean;
+  showFlats: boolean;
+  showDegrees: boolean;
+}
+
+export interface GlobalConfigUrlPatch {
+  root?: Note;
+  scaleType?: ScaleType;
+  mode?: ScaleMode;
+  highlightRoots?: boolean;
+  showFlats?: boolean;
+  showDegrees?: boolean;
+}
+
+/**
+ * Encode the shareable subset of GlobalConfig into a URLSearchParams instance.
+ */
+export function encodeGlobalConfigToParams(
+  config: GlobalConfigUrlSlice
+): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set(URL_PARAM_KEYS.root, config.scale.root);
+  params.set(URL_PARAM_KEYS.scaleType, config.scale.type);
+  if (config.scale.mode) {
+    params.set(URL_PARAM_KEYS.mode, config.scale.mode);
+  }
+  params.set(URL_PARAM_KEYS.highlightRoots, config.highlightRoots ? "1" : "0");
+  params.set(URL_PARAM_KEYS.showFlats, config.showFlats ? "1" : "0");
+  params.set(URL_PARAM_KEYS.showDegrees, config.showDegrees ? "1" : "0");
+  return params;
+}
+
+/**
+ * Decode a URLSearchParams instance into a patch of validated GlobalConfig
+ * values. Missing or invalid values are omitted from the returned patch
+ * rather than throwing, so callers can apply only what is present and valid.
+ */
+export function decodeParamsToGlobalConfigPatch(
+  params: URLSearchParams
+): GlobalConfigUrlPatch {
+  const patch: GlobalConfigUrlPatch = {};
+
+  const root = params.get(URL_PARAM_KEYS.root);
+  if (root !== null && isValidNote(root)) {
+    patch.root = root;
+  }
+
+  const scaleType = params.get(URL_PARAM_KEYS.scaleType);
+  if (scaleType !== null && isValidScaleType(scaleType)) {
+    patch.scaleType = scaleType;
+  }
+
+  const mode = params.get(URL_PARAM_KEYS.mode);
+  if (mode !== null && isValidScaleMode(mode)) {
+    patch.mode = mode;
+  }
+
+  const highlightRoots = params.get(URL_PARAM_KEYS.highlightRoots);
+  if (highlightRoots !== null && isBooleanFlag(highlightRoots)) {
+    patch.highlightRoots = highlightRoots === "1";
+  }
+
+  const showFlats = params.get(URL_PARAM_KEYS.showFlats);
+  if (showFlats !== null && isBooleanFlag(showFlats)) {
+    patch.showFlats = showFlats === "1";
+  }
+
+  const showDegrees = params.get(URL_PARAM_KEYS.showDegrees);
+  if (showDegrees !== null && isBooleanFlag(showDegrees)) {
+    patch.showDegrees = showDegrees === "1";
+  }
+
+  return patch;
+}

--- a/src/features/globalConfig/useUrlSyncedGlobalConfig.ts
+++ b/src/features/globalConfig/useUrlSyncedGlobalConfig.ts
@@ -1,0 +1,124 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  selectScale,
+  selectIsMonochrome,
+  selectShowFlats,
+  selectShowDegrees,
+  setScale,
+  setHighlightRoots,
+  setShowFlats,
+  setShowDegrees,
+} from "./globalConfigSlice";
+import {
+  decodeParamsToGlobalConfigPatch,
+  encodeGlobalConfigToParams,
+  GlobalConfigUrlSlice,
+} from "./urlConfigParams";
+
+/**
+ * Keeps the shareable Scale Display Configuration (scale, root, color mode,
+ * flat display, number display) in sync with the page's URL query string in
+ * both directions:
+ *  - URL -> store: params found in the URL are applied whenever the URL
+ *    itself changes (initial load, navigation, back/forward), taking
+ *    precedence over any locally restored defaults (FR-007).
+ *  - store -> URL: any change to the five settings is mirrored back into
+ *    the URL (FR-006).
+ *
+ * Spec: specs/002-url-params/spec.md
+ */
+export function useUrlSyncedGlobalConfig(): void {
+  const dispatch = useDispatch();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const scale = useSelector(selectScale);
+  const highlightRoots = useSelector(selectIsMonochrome);
+  const showFlats = useSelector(selectShowFlats);
+  const showDegrees = useSelector(selectShowDegrees);
+
+  // Read fresh, current store values from the URL -> store effect without
+  // making them reactive dependencies of that effect (see below).
+  const currentConfigRef = useRef<GlobalConfigUrlSlice>({
+    scale,
+    highlightRoots,
+    showFlats,
+    showDegrees,
+  });
+  currentConfigRef.current = { scale, highlightRoots, showFlats, showDegrees };
+
+  // The store -> URL effect intentionally skips its very first invocation:
+  // on mount, the URL -> store effect below may dispatch changes that have
+  // not yet propagated to this hook's `scale`/etc. closures in the same
+  // commit. Skipping the first write lets the resulting re-render (if any)
+  // supply settled, correct values before anything is written back to the
+  // URL, avoiding a stale write that would clobber the very params a shared
+  // link just supplied.
+  const isFirstWriteRef = useRef(true);
+
+  // URL -> store: only reacts to the URL's own query string changing
+  // (not to store changes), so it never fights a live user-driven edit.
+  useEffect(() => {
+    const patch = decodeParamsToGlobalConfigPatch(searchParams);
+    const current = currentConfigRef.current;
+
+    const hasScaleOverride =
+      patch.root !== undefined ||
+      patch.scaleType !== undefined ||
+      patch.mode !== undefined;
+    if (hasScaleOverride) {
+      const nextScale = {
+        root: patch.root ?? current.scale.root,
+        type: patch.scaleType ?? current.scale.type,
+        mode: patch.mode ?? current.scale.mode,
+      };
+      const scaleChanged =
+        nextScale.root !== current.scale.root ||
+        nextScale.type !== current.scale.type ||
+        nextScale.mode !== current.scale.mode;
+      if (scaleChanged) {
+        dispatch(setScale(nextScale));
+      }
+    }
+
+    if (
+      patch.highlightRoots !== undefined &&
+      patch.highlightRoots !== current.highlightRoots
+    ) {
+      dispatch(setHighlightRoots(patch.highlightRoots));
+    }
+    if (patch.showFlats !== undefined && patch.showFlats !== current.showFlats) {
+      dispatch(setShowFlats(patch.showFlats));
+    }
+    if (
+      patch.showDegrees !== undefined &&
+      patch.showDegrees !== current.showDegrees
+    ) {
+      dispatch(setShowDegrees(patch.showDegrees));
+    }
+  }, [searchParams, dispatch]);
+
+  // store -> URL: reacts only to the five settings changing.
+  useEffect(() => {
+    if (isFirstWriteRef.current) {
+      isFirstWriteRef.current = false;
+      return;
+    }
+
+    const nextQuery = encodeGlobalConfigToParams({
+      scale,
+      highlightRoots,
+      showFlats,
+      showDegrees,
+    }).toString();
+
+    if (nextQuery !== searchParams.toString()) {
+      router.replace(`${pathname}?${nextQuery}`, { scroll: false });
+    }
+  }, [scale, highlightRoots, showFlats, showDegrees, pathname, router, searchParams]);
+}


### PR DESCRIPTION
Reflects the selected scale, root, color mode, flat display, and number display in the URL so views can be shared or bookmarked, restoring them on load and keeping the address bar live-updated as settings change.